### PR TITLE
Uses Title Case for statuses and errors

### DIFF
--- a/custom_components/elegoo_printer/definitions.py
+++ b/custom_components/elegoo_printer/definitions.py
@@ -147,7 +147,9 @@ PRINTER_STATUS: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         key="print_status",
         name="Print Status",
         icon="mdi:file",
-        value_fn=lambda self: self.coordinator.data.status.current_status.name.title(),
+        value_fn=lambda self: self.coordinator.data.status.current_status.name.replace(
+            "_", " "
+        ).title(),
         available_fn=lambda self: self.coordinator.data.status.current_status
         is not None,
     ),
@@ -155,7 +157,9 @@ PRINTER_STATUS: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         key="print_error",
         name="Print Error",
         icon="mdi:file",
-        value_fn=lambda self: self.coordinator.data.status.print_info.error_number.name.title(),
+        value_fn=lambda self: self.coordinator.data.status.print_info.error_number.name.replace(
+            "_", " "
+        ).title(),
         available_fn=lambda self: self.coordinator.data.status.print_info.error_number
         is not None,
     ),

--- a/custom_components/elegoo_printer/definitions.py
+++ b/custom_components/elegoo_printer/definitions.py
@@ -147,7 +147,7 @@ PRINTER_STATUS: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         key="print_status",
         name="Print Status",
         icon="mdi:file",
-        value_fn=lambda self: self.coordinator.data.status.current_status.name.lower(),
+        value_fn=lambda self: self.coordinator.data.status.current_status.name.title(),
         available_fn=lambda self: self.coordinator.data.status.current_status
         is not None,
     ),
@@ -155,7 +155,7 @@ PRINTER_STATUS: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         key="print_error",
         name="Print Error",
         icon="mdi:file",
-        value_fn=lambda self: self.coordinator.data.status.print_info.error_number.name.lower(),
+        value_fn=lambda self: self.coordinator.data.status.print_info.error_number.name.title(),
         available_fn=lambda self: self.coordinator.data.status.print_info.error_number
         is not None,
     ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the formatting of print status and error messages to capitalize the first letter of each word for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->