### PR TITLE
Fix github repo url on descriptions

### DIFF
--- a/custom_components/elegoo_printer/const.py
+++ b/custom_components/elegoo_printer/const.py
@@ -7,4 +7,4 @@ LOGGER: Logger = getLogger(__package__)
 CONF_CENTAURI_CARBON = "centauri_carbon"
 CONF_PROXY_ENABLED = "proxy_enabled"
 DOMAIN = "elegoo_printer"
-ATTRIBUTION = "Data provided by https://github.com/danielcherubini/elegoo_printer"
+ATTRIBUTION = "Data provided by https://github.com/danielcherubini/elegoo-homeassistant"

--- a/custom_components/elegoo_printer/translations/en.json
+++ b/custom_components/elegoo_printer/translations/en.json
@@ -2,7 +2,7 @@
   "options": {
     "step": {
       "init": {
-        "description": "If you need help with the configuration have a look here: https://github.com/danielcherubini/elegoo_printer",
+        "description": "If you need help with the configuration have a look here: https://github.com/danielcherubini/elegoo-homeassistant",
         "data": {
           "ip_address": "Printer IP Address",
           "centauri_carbon": "Is this an FDM Printer",
@@ -14,7 +14,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "If you need help with the configuration have a look here: https://github.com/danielcherubini/elegoo_printer",
+        "description": "If you need help with the configuration have a look here: https://github.com/danielcherubini/elegoo-homeassistant",
         "data": {
           "ip_address": "Printer IP Address",
           "centauri_carbon": "Is this an FDM Printer",


### PR DESCRIPTION
The github repo is wrong, so it can be misleading for some less experienced users to understand where to go to see more about the component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated URLs in help text and attribution to point to the new project location: https://github.com/danielcherubini/elegoo-homeassistant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->