### PR TITLE
Replace printer IP with proxy IP in websocket messages

### DIFF
--- a/custom_components/elegoo_printer/elegoo_sdcp/server.py
+++ b/custom_components/elegoo_printer/elegoo_sdcp/server.py
@@ -377,7 +377,15 @@ class ElegooPrinterServer:
                                 (
                                     await dest.send_bytes(msg.data)
                                     if msg.type == WSMsgType.BINARY
-                                    else await dest.send_str(msg.data)
+                                    else await dest.send_str(
+                                            msg.data.replace(
+                                                self.printer.ip_address,
+                                                self.get_local_ip()
+                                            ).replace(
+                                                f"{self.get_local_ip()}/",
+                                                f"{self.get_local_ip()}:{WEBSOCKET_PORT}/"
+                                            )
+                                        )
                                 )
                             elif msg.type == WSMsgType.CLOSE:
                                 break


### PR DESCRIPTION
When looking at the web UI, it's still making some requests direct to the printer. This includes the video stream.

After some investigation, this is because the JS of the web UI is using the IP and URLs provided by websocket messages.

By replacing the printer IP with the proxy IP, everything ends up going through the proxy as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket message handling to correctly rewrite IP addresses in text messages, ensuring proper communication between the printer and local proxy.

* **Chores**
  * Updated internal message forwarding logic for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->