### PR TITLE
Adds a blueprint for phone notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,23 @@ This integration is actively being developed. Future updates may include:
 
 Stay tuned for updates and feel free to contribute with feature requests and bug reports!
 
+## Automation Blueprints
+
+This integration includes a blueprint to send notifications to your mobile device with the progress of your prints.
+
+[![Open your Home Assistant instance and import the blueprint.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https://github.com/danielcherubini/elegoo-homeassistant/blob/main/blueprints/automation/elegoo_printer/elegoo_printer_progress.yaml)
+
+### Blueprint: Elegoo Printer Progress Notification
+
+This blueprint sends notifications to your mobile device with the progress of your prints. You can configure the following:
+
+- **Percent Complete Sensor:** The sensor that tracks the print progress.
+- **Notification Device:** The mobile device to send notifications to.
+- **Notification Frequency:** How often to send notifications (e.g., every 5% of progress).
+- **Printer Camera:** The camera entity for your printer.
+- **Dashboard URL (Optional):** A URL to open when the notification is clicked.
+- **Notification Group (Optional):** A unique name for the notification group, channel, and tag.
+
 ## Support and Contributions
 
 For any issues or feature requests, please [open an issue](https://github.com/danielcherubini/elegoo-homeassistant/issues) on the GitHub repository. Contributions are welcome!

--- a/blueprints/automation/elegoo_printer/elegoo_printer_progress.yaml
+++ b/blueprints/automation/elegoo_printer/elegoo_printer_progress.yaml
@@ -1,0 +1,122 @@
+
+blueprint:
+  name: Elegoo Printer Progress Notification
+  description: Sends a notification with the progress of an Elegoo printer.
+  author: Daniel Cherubini
+  homeassistant:
+    min_version: 2024.6.0
+  domain: automation
+  input:
+    percent_complete_sensor:
+      name: Percent Complete Sensor
+      description: The printer's percent complete sensor.
+      selector:
+        entity:
+          domain: sensor
+          integration: elegoo_printer
+    notify_device:
+      name: Notification Device
+      description: The device to send notifications to.
+      selector:
+        device:
+          integration: mobile_app
+    percentage_divisor:
+      name: Notification Frequency
+      description: >-
+        Notify when the percentage complete is divisible by this number. Use 1
+        to be notified on every percentage change.
+      selector:
+        select:
+          options:
+            - "1"
+            - "2"
+            - "5"
+      default: "5"
+    camera_entity:
+      name: Printer Camera
+      description: The camera entity for the printer.
+      selector:
+        entity:
+          domain: camera
+    dashboard_url:
+      name: Dashboard URL (Optional)
+      description: The URL to open when the notification is clicked.
+      default: ""
+    notification_group:
+      name: Notification Group
+      description: A unique name for the notification group, channel, and tag.
+      default: "elegoo-printer"
+
+mode: single
+max_exceeded: silent
+
+variables:
+  percent_complete_entity: !input percent_complete_sensor
+  elegoo_printer_device: "{{ device_id(percent_complete_entity) }}"
+  notify_device: !input notify_device
+  percentage_divisor: !input percentage_divisor
+  camera_entity: !input camera_entity
+  dashboard_url: !input dashboard_url
+  notification_group: !input notification_group
+  file_name_entity: >-
+    {{ device_entities(elegoo_printer_device) | select('search', '_file_name') |
+    first }}
+  remaining_print_time_entity: >-
+    {{ device_entities(elegoo_printer_device) | select('search',
+    '_remaining_print_time') | first }}
+
+trigger:
+  - platform: state
+    entity_id: !input percent_complete_sensor
+
+condition: []
+
+action:
+  - if:
+      - condition: numeric_state
+        entity_id: !input percent_complete_sensor
+        below: 100
+    then:
+      - if:
+          - condition: template
+            value_template: >-
+              {{ states(percent_complete_entity) | int % (percentage_divisor | int) == 0 }}
+          - condition: template
+            value_template: "{{ notify_device != '' }}"
+        then:
+          - device_id: !input notify_device
+            domain: mobile_app
+            type: notify
+            title: "Printing: {{ states(percent_complete_entity) }}%"
+            message: "{{ states(file_name_entity) }}"
+            data:
+              chronometer: true
+              when: "{{ (states(remaining_print_time_entity)|float * 60)|int }}"
+              when_relative: true
+              progress: "{{ states(percent_complete_entity)|int }}"
+              progress_max: 100
+              image: "/api/camera_proxy/{{ camera_entity }}"
+              url: "{{ dashboard_url }}"
+              clickAction: "{{ dashboard_url }}"
+              group: "{{ notification_group }}"
+              channel: "{{ notification_group }}"
+              tag: "{{ notification_group }}"
+              alert_once: true
+              sticky: true
+    else:
+      - if:
+          - condition: template
+            value_template: "{{ notify_device != '' }}"
+        then:
+          - device_id: !input notify_device
+            domain: mobile_app
+            type: notify
+            message: Print has finished
+            data:
+              url: "{{ dashboard_url }}"
+              clickAction: "{{ dashboard_url }}"
+              group: "{{ notification_group }}"
+              channel: "{{ notification_group }}"
+              tag: "{{ notification_group }}"
+              sticky: true
+              alert_once: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new automation blueprint for Home Assistant that sends print progress notifications from Elegoo printers to mobile devices, including progress percentage, file name, remaining time, and camera image.
  * Added configurable options for notification frequency, device selection, dashboard links, and notification grouping.

* **Documentation**
  * Updated the README with a new "Automation Blueprints" section detailing the Elegoo Printer Progress Notification blueprint and its setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->