### PR TITLE
FDM Printers use PNGs

### DIFF
--- a/custom_components/elegoo_printer/api.py
+++ b/custom_components/elegoo_printer/api.py
@@ -209,14 +209,14 @@ class ElegooPrinterApiClient:
                 with PILImage.open(BytesIO(response.content)) as img:
                     with BytesIO() as output:
                         rgb_img = img.convert("RGB")
-                        rgb_img.save(output, format="JPEG")
+                        rgb_img.save(output, format="PNG")
                         jpg_bytes = output.getvalue()
-                        LOGGER.debug("get_thumbnail converted image to jpg")
+                        LOGGER.debug("get_thumbnail converted image to png")
                         thumbnail_image = ElegooImage(
                             url=task.thumbnail,
                             image_bytes=jpg_bytes,
                             last_updated_timestamp=task.begin_time,
-                            content_type="image/jpeg",
+                            content_type="image/png",
                         )
                         return thumbnail_image
             except Exception as e:

--- a/custom_components/elegoo_printer/api.py
+++ b/custom_components/elegoo_printer/api.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.config_validation import url
 from homeassistant.helpers.httpx_client import get_async_client
 from PIL import Image as PILImage
 
@@ -200,7 +199,7 @@ class ElegooPrinterApiClient:
                 if self.printer.printer_type == PrinterType.FDM:
                     LOGGER.debug("get_thumbnail is FDM printer")
                     return ElegooImage(
-                        url=task.thumbnail,
+                        image_url=task.thumbnail,
                         image_bytes=response.content,
                         last_updated_timestamp=task.begin_time,
                         content_type="image/png",
@@ -213,7 +212,7 @@ class ElegooPrinterApiClient:
                         jpg_bytes = output.getvalue()
                         LOGGER.debug("get_thumbnail converted image to png")
                         thumbnail_image = ElegooImage(
-                            url=task.thumbnail,
+                            image_url=task.thumbnail,
                             image_bytes=jpg_bytes,
                             last_updated_timestamp=task.begin_time,
                             content_type="image/png",

--- a/custom_components/elegoo_printer/api.py
+++ b/custom_components/elegoo_printer/api.py
@@ -196,13 +196,17 @@ class ElegooPrinterApiClient:
                 )
                 response.raise_for_status()
                 LOGGER.debug("get_thumbnail response status: %s", response.status_code)
-                if self.printer.printer_type == PrinterType.FDM:
-                    LOGGER.debug("get_thumbnail is FDM printer")
+                content_type = response.headers.get("content-type", "image/png")
+
+                if content_type and content_type == "image/png":
+                    # Normalize common header forms like "image/png; charset=binary"
+                    content_type = content_type.split(";", 1)[0].strip().lower()
+                    LOGGER.debug("get_thumbnail (FDM) content-type: %s", content_type)
                     return ElegooImage(
                         image_url=task.thumbnail,
                         image_bytes=response.content,
                         last_updated_timestamp=task.begin_time,
-                        content_type="image/png",
+                        content_type=content_type or "image/png",
                     )
 
                 with PILImage.open(BytesIO(response.content)) as img:

--- a/custom_components/elegoo_printer/api.py
+++ b/custom_components/elegoo_printer/api.py
@@ -16,7 +16,6 @@ from custom_components.elegoo_printer.elegoo_sdcp.client import ElegooPrinterCli
 from custom_components.elegoo_printer.elegoo_sdcp.models.elegoo_image import ElegooImage
 from custom_components.elegoo_printer.elegoo_sdcp.models.enums import (
     ElegooFan,
-    PrinterType,
 )
 from custom_components.elegoo_printer.elegoo_sdcp.models.print_history_detail import (
     PrintHistoryDetail,

--- a/custom_components/elegoo_printer/elegoo_sdcp/models/elegoo_image.py
+++ b/custom_components/elegoo_printer/elegoo_sdcp/models/elegoo_image.py
@@ -8,9 +8,16 @@ from homeassistant.components.image import Image
 class ElegooImage:
     """Returns the cover image"""
 
-    def __init__(self, url: str, bytes: bytes, last_updated_timestamp: int):
+    def __init__(
+        self,
+        url: str,
+        image_bytes: bytes,
+        last_updated_timestamp: int,
+        content_type: str,
+    ):
         self._image_url = url
-        self._bytes = bytes
+        self._bytes = image_bytes
+        self._content_type = content_type
         try:
             self._image_last_updated = datetime.fromtimestamp(
                 float(last_updated_timestamp)
@@ -24,5 +31,8 @@ class ElegooImage:
     def get_last_update_time(self) -> datetime:
         return self._image_last_updated
 
+    def get_content_type(self) -> str:
+        return self._content_type
+
     def get_image(self) -> Image:
-        return Image("image/jpg", self._bytes)
+        return Image(self._content_type, self._bytes)

--- a/custom_components/elegoo_printer/elegoo_sdcp/models/elegoo_image.py
+++ b/custom_components/elegoo_printer/elegoo_sdcp/models/elegoo_image.py
@@ -10,12 +10,12 @@ class ElegooImage:
 
     def __init__(
         self,
-        url: str,
+        image_url: str,
         image_bytes: bytes,
         last_updated_timestamp: int,
         content_type: str,
     ):
-        self._image_url = url
+        self._image_url = image_url
         self._bytes = image_bytes
         self._content_type = content_type
         try:

--- a/custom_components/elegoo_printer/image.py
+++ b/custom_components/elegoo_printer/image.py
@@ -58,7 +58,7 @@ class CoverImage(ElegooPrinterEntity, ImageEntity):
         """
         Initialize a CoverImage entity for the Elegoo Printer.
 
-        Sets up the entity with the provided Home Assistant instance, data coordinator, and entity description. Assigns a unique ID, sets the content type to BMP, and records the initial image update timestamp.
+        Sets up the entity with the provided Home Assistant instance, data coordinator, and entity description. Assigns a unique ID, sets the content type to PNG, and records the initial image update timestamp.
         """
         super().__init__(coordinator)
         ImageEntity.__init__(self, hass=hass)

--- a/custom_components/elegoo_printer/image.py
+++ b/custom_components/elegoo_printer/image.py
@@ -80,7 +80,7 @@ class CoverImage(ElegooPrinterEntity, ImageEntity):
                 self._attr_image_last_updated = thumbnail_image.get_last_update_time()
                 self._cached_image = thumbnail_image.get_image()
                 self.image_url = task.thumbnail
-                self._attr_content_type = "image/jpg"
+                self._attr_content_type = thumbnail_image.get_content_type()
                 return thumbnail_image.get_bytes()
 
         elif self._cached_image:


### PR DESCRIPTION
Fixes #203 

<img width="905" height="524" alt="image" src="https://github.com/user-attachments/assets/2432c01a-4383-4513-a827-e84093dc1caa" />


<img width="927" height="924" alt="image" src="https://github.com/user-attachments/assets/be0bd0aa-5fbe-4895-a0dd-8c1f14dd0a18" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Thumbnails now preserve/return PNG data for FDM printers and convert non-FDM thumbnails to PNG for consistent handling.
- **Bug Fixes**
  - Thumbnail content type is reported accurately (uses actual image content type).
  - Image bytes, URLs and timestamps are aligned so cached thumbnails display consistently across printer types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->