### PR TITLE
Change websockets to use asyncio.create_task instead of hass.async_create_task to stop integration blocking startup

### DIFF
--- a/custom_components/elegoo_printer/websocket/server.py
+++ b/custom_components/elegoo_printer/websocket/server.py
@@ -235,7 +235,7 @@ class ElegooPrinterServer:
                         "An unexpected error occurred during video streaming"
                     )
                 return response
-        except (asyncio.TimeoutError, aiohttp.ClientError):
+        except (TimeoutError, aiohttp.ClientError):
             self.logger.exception("Error proxying video stream")
             return web.Response(status=502, text="Bad Gateway")
 
@@ -313,7 +313,7 @@ class ElegooPrinterServer:
                     if task.exception():
                         raise task.exception()  # noqa: TRY301
 
-        except (asyncio.TimeoutError, aiohttp.ClientError):
+        except (TimeoutError, aiohttp.ClientError) as e:
             msg = f"WebSocket connection to printer failed: {e}"
             self.logger.warning(msg)
             self._is_connected = False

--- a/custom_components/elegoo_printer/websocket/server.py
+++ b/custom_components/elegoo_printer/websocket/server.py
@@ -297,11 +297,11 @@ class ElegooPrinterServer:
                         self.logger.debug(msg)
                         raise
 
-                to_printer = self.hass.async_create_task(
+                to_printer = asyncio.create_task(
                     forward(client_ws, remote_ws, "client-to-printer")
                 )
                 tasks.add(to_printer)
-                to_client = self.hass.async_create_task(
+                to_client = asyncio.create_task(
                     forward(remote_ws, client_ws, "printer-to-client")
                 )
                 tasks.add(to_client)

--- a/custom_components/elegoo_printer/websocket/server.py
+++ b/custom_components/elegoo_printer/websocket/server.py
@@ -305,7 +305,7 @@ class ElegooPrinterServer:
                 tasks.add(to_printer)
                 to_client = asyncio.create_task(
                     forward(remote_ws, client_ws, "printer-to-client"),
-                    name="elegoo_ws:printer-to-client",
+                    name="elegoo_ws:printer_to_client",
                 )
                 tasks.add(to_client)
                 done, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)


### PR DESCRIPTION
This integration has been blocking HA from finishing it's startup until it decides to carry on. It looks like it's due to using `hass.async_create_task` for the websocket loops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched WebSocket stream scheduling to native asyncio tasks; end-to-end behavior remains unchanged.

* **Bug Fix**
  * Improved WebSocket close handling for more reliable connections and cleaner session shutdowns.

* **Chores**
  * Added task naming and diagnostic improvements to aid logging and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->