### PR TITLE
Replace ping with UDP discovery for printer connectivity tests

### DIFF
--- a/custom_components/elegoo_printer/api.py
+++ b/custom_components/elegoo_printer/api.py
@@ -112,8 +112,11 @@ class ElegooPrinterApiClient:
             session=session,
         )
 
-        # Ping the printer to check if it's available
-        printer_reachable = await self.client.ping_printer(ping_timeout=5.0)
+        # Discover the printer to check if it's available
+        discovered_printers = await hass.async_add_executor_job(
+            self.client.discover_printer, printer.ip_address
+        )
+        printer_reachable = len(discovered_printers) > 0
 
         if not printer_reachable:
             logger.warning(
@@ -216,8 +219,11 @@ class ElegooPrinterApiClient:
             printer.ip_address,
         )
 
-        # Ping the printer to check if it's available
-        printer_reachable = await self.client.ping_printer(ping_timeout=5.0)
+        # Discover the printer to check if it's available
+        discovered_printers = await self.hass.async_add_executor_job(
+            self.client.discover_printer, printer.ip_address
+        )
+        printer_reachable = len(discovered_printers) > 0
 
         if not printer_reachable:
             self._logger.debug(

--- a/custom_components/elegoo_printer/websocket/client.py
+++ b/custom_components/elegoo_printer/websocket/client.py
@@ -526,51 +526,6 @@ class ElegooPrinterClient:
 
         return None
 
-    async def ping_printer(self, ping_timeout: float = 5.0) -> bool:
-        """
-        Test if printer is reachable by checking TCP port connectivity.
-
-        Args:
-            ping_timeout: Connection timeout in seconds
-
-        Returns:
-            bool: True if printer is reachable, False otherwise
-
-        """
-        # Try port 80 first (HTTP), then 3030 (WebSocket)
-        ports_to_check = [80, WEBSOCKET_PORT]
-
-        for port in ports_to_check:
-            try:
-                # Simple TCP connection test
-                _, writer = await asyncio.wait_for(
-                    asyncio.open_connection(self.printer.ip_address, port),
-                    timeout=ping_timeout / len(ports_to_check),  # Split timeout
-                )
-                writer.close()
-                await writer.wait_closed()
-            except (TimeoutError, ConnectionRefusedError, OSError) as e:
-                self.logger.debug(
-                    "Printer ping failed at %s:%s - %s",
-                    self.printer.ip_address,
-                    port,
-                    type(e).__name__,
-                )
-                continue
-            except asyncio.CancelledError:
-                self.logger.debug("Ping cancelled - Home Assistant shutting down")
-                return False
-            else:
-                self.logger.debug(
-                    "Printer ping successful at %s:%s", self.printer.ip_address, port
-                )
-                return True
-
-        self.logger.debug(
-            "Printer at %s is not reachable on any port", self.printer.ip_address
-        )
-        return False
-
     async def connect_printer(self, printer: Printer, *, proxy_enabled: bool) -> bool:
         """Establish an asynchronous connection to the Elegoo printer."""
         if self.is_connected:

--- a/debug.py
+++ b/debug.py
@@ -12,7 +12,7 @@ from custom_components.elegoo_printer.websocket.client import ElegooPrinterClien
 from custom_components.elegoo_printer.sdcp.const import DEBUG
 
 LOG_LEVEL = "INFO"
-PRINTER_IP = os.getenv("PRINTER_IP", "10.0.0.184")
+PRINTER_IP = os.getenv("PRINTER_IP", "10.0.0.212")
 
 logger.remove()
 logger.add(sys.stdout, colorize=DEBUG, level=LOG_LEVEL)
@@ -75,15 +75,6 @@ async def main() -> None:
             elegoo_printer = ElegooPrinterClient(
                 ip_address=PRINTER_IP, session=session, logger=logger
             )
-
-            # Test ping functionality first if specific IP provided
-            logger.info(f"Testing ping to printer at {PRINTER_IP}...")
-            ping_result = await elegoo_printer.ping_printer(ping_timeout=5.0)
-            if ping_result:
-                logger.info("✓ Ping successful - printer WebSocket is reachable")
-            else:
-                logger.warning("✗ Ping failed - printer WebSocket is not reachable")
-                logger.info("This is expected if printer is off or WebSocket service not running")
 
             # Discover specific printer first
             logger.info(f"🔍 Discovering printer at {PRINTER_IP}...")

--- a/uv.lock
+++ b/uv.lock
@@ -631,7 +631,7 @@ wheels = [
 
 [[package]]
 name = "elegoo-printer"
-version = "2.3.0b17"
+version = "2.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "colorlog" },


### PR DESCRIPTION
- Removed ping_printer method that used TCP port checking
- Updated api.py to use discover_printer for connectivity tests
- Run discovery in executor to avoid blocking event loop
- Cleaned up debug.py to remove ping test
- Discovery protocol is more consistent with printer behavior