### PR TITLE
Fix chamber light toggle behavior by maintaining state

### DIFF
--- a/custom_components/elegoo_printer/light.py
+++ b/custom_components/elegoo_printer/light.py
@@ -89,8 +89,8 @@ class ElegooLight(ElegooPrinterEntity, LightEntity):
         # For the standard on/off light
         result = self.entity_description.value_fn(self.light_status)
         LOGGER.debug(
-            f"Chamber Light is_on check: second_light={self.light_status.second_light}, "
-            f"is_on={result}"
+            f"Chamber Light is_on: second_light={self.light_status.second_light}, "
+            f"result={result}"
         )
         return result
 
@@ -102,7 +102,7 @@ class ElegooLight(ElegooPrinterEntity, LightEntity):
         to the printer. Updates the coordinator state after the operation.
         """
         LOGGER.debug(
-            f"Chamber Light turn_on called. Current second_light={self.light_status.second_light}"
+            f"Chamber Light turn_on: second_light={self.light_status.second_light}"
         )
 
         # Skip command if light is already on (avoid toggle behavior)
@@ -125,7 +125,7 @@ class ElegooLight(ElegooPrinterEntity, LightEntity):
         to the printer. Updates the coordinator state after the operation.
         """
         LOGGER.debug(
-            f"Chamber Light turn_off called. Current second_light={self.light_status.second_light}"
+            f"Chamber Light turn_off: second_light={self.light_status.second_light}"
         )
 
         # Skip command if light is already off (avoid toggle behavior)


### PR DESCRIPTION
The printer firmware appears to interprets light commands as toggles rather than explicit on/off operations. When sending a light command while the light is already in that state, the printer toggles it to the opposite state.

For example:
- Light is ON (second_light=1)
- User clicks ON button
- Integration sends SecondLight=1
- Printer toggles light to OFF

This fix prevents the toggle behavior by checking the current light state before sending commands:
- async_turn_on: Skip if second_light is already truthy (ON)
- async_turn_off: Skip if second_light is already falsy (OFF)

Also adds comprehensive debug logging to track state changes and command execution.

This builds on commit 45bce595 which fixed the cached state mutation issue, but the printer's toggle behavior required this additional check.

Tested and confirmed working on my Elegoo Centauri Carbon (firmware 1.1.46) 🤷

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents sending redundant on/off commands when the light is already in the desired state.
  * Adds additional debug logging around state checks and control actions for clearer diagnostics.
  * Ensures the system refreshes state after issuing a change so UI/status stays up to date.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->