### PR TITLE
Fix OptionsFlow config_entry setter for HA 2025.12+ compatibility

### DIFF
--- a/custom_components/elegoo_printer/config_flow.py
+++ b/custom_components/elegoo_printer/config_flow.py
@@ -536,7 +536,7 @@ class ElegooOptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
+        self._config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
## Summary
- Fixes AttributeError in config flow preventing users from configuring options in Home Assistant 2025.12+
- Changes `ElegooOptionsFlowHandler.__init__` to use `_config_entry` instead of `config_entry` property

## Changes
- Modified `custom_components/elegoo_printer/config_flow.py:539` to use internal `_config_entry` attribute
- This bypasses the deprecated setter that was removed in HA 2025.12 while maintaining functionality

## Testing
- ✅ All 111 tests pass
- ✅ Linting checks pass
- ✅ Code formatted correctly

## Closes
Fixes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements with no user-visible impact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->