### PR TITLE
Increase print progress percentage precision

### DIFF
--- a/custom_components/elegoo_printer/definitions.py
+++ b/custom_components/elegoo_printer/definitions.py
@@ -403,6 +403,7 @@ PRINTER_STATUS_COMMON: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         icon="mdi:percent",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda printer_data: printer_data.status.print_info.percent_complete,
     ),
     ElegooPrinterSensorEntityDescription(

--- a/custom_components/elegoo_printer/sdcp/models/status.py
+++ b/custom_components/elegoo_printer/sdcp/models/status.py
@@ -75,8 +75,8 @@ class PrintInfo:
         remaining_ticks (int | None): Remaining print time in ms, or None if unknown.
         progress (int | None): Device-reported print progress (0-100), or None
             if unknown.
-        percent_complete (int | None): Percentage complete, clamped to [0, 100], or None
-            if unknown.
+        percent_complete (float | None): Percentage complete, clamped to
+            [0, 100], or None if unknown.
         print_speed_pct (int): The current print speed as a percentage.
         filename (str): Print File Name.
         error_number (ElegooPrintError): Error Number (refer to documentation).
@@ -125,7 +125,7 @@ class PrintInfo:
         self.print_speed_pct: int = data.get("PrintSpeedPct", 100)
         self.end_time = None
         # percent_complete is optional when printer is idle/unknown
-        self.percent_complete: int | None = None
+        self.percent_complete: float | None = None
 
         percent_complete = None
         # Report progress only during an active job to avoid leaking stale values.
@@ -142,14 +142,14 @@ class PrintInfo:
         }
         if self.status in active_statuses:
             if self.progress is not None:
-                percent_complete = int(self.progress)
+                percent_complete = round(float(self.progress), 2)
             elif (
                 self.current_layer is not None
                 and self.total_layers is not None
                 and self.total_layers > 0
             ):
-                # Optional: round to reduce downward bias from truncation
-                percent_complete = round((self.current_layer / self.total_layers) * 100)
+                ratio = self.current_layer / self.total_layers
+                percent_complete = round(ratio * 100, 2)
         else:
             percent_complete = None
 


### PR DESCRIPTION
## Summary
- Changed `percent_complete` from `int` to `float` with 2 decimal places to match the precision shown on the printer's own screen (e.g., 61.45% instead of 61%)
- Updated both the device-reported progress path and the layer-based fallback calculation
- Added `suggested_display_precision=2` to the sensor definition for proper HA display

Closes #319

## Test plan
- [x] All 111 existing tests pass
- [x] Linting passes
- [ ] Verify on a physical printer that the percent complete sensor now shows decimal values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved printer progress percentage display to show values with two decimal place precision for more accurate progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->