### PR TITLE
fix: use closest match for print speed preset selection

### DIFF
--- a/custom_components/elegoo_printer/definitions.py
+++ b/custom_components/elegoo_printer/definitions.py
@@ -179,6 +179,7 @@ def _get_closest_print_speed_preset(speed_pct: int | None) -> str | None:
 
     return closest_name
 
+
 # Attributes common to both V1 (MQTT) and V3 (WebSocket/SDCP) printers
 PRINTER_ATTRIBUTES_COMMON: tuple[ElegooPrinterSensorEntityDescription, ...] = (
     ElegooPrinterSensorEntityDescription(
@@ -764,9 +765,7 @@ PRINTER_SELECT_TYPES: tuple[ElegooPrinterSelectEntityDescription, ...] = (
         options_map=PRINT_SPEED_PRESETS,
         current_option_fn=lambda printer_data: _get_closest_print_speed_preset(
             printer_data.status.print_info.print_speed_pct
-            if printer_data
-            and printer_data.status
-            and printer_data.status.print_info
+            if printer_data and printer_data.status and printer_data.status.print_info
             else None
         ),
         select_option_fn=lambda api, value: api.async_set_print_speed(value),


### PR DESCRIPTION
When the printer reports a speed that doesn't exactly match a preset (e.g., 160% when Ludicrous mode is selected but clamped by firmware), the speed selector would show blank. This fix implements a closest-match algorithm to find the nearest preset, making the integration more robust.

Fixes #318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and improved print-speed preset selection for more consistent, accurate matching to the printer's current speed.

* **Bug Fixes**
  * Handles missing or unavailable printer speed data more gracefully to avoid incorrect preset display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->