### PR TITLE
Update blueprint to use modern template syntax

### DIFF
--- a/blueprints/automation/elegoo_printer/elegoo_printer_progress.yaml
+++ b/blueprints/automation/elegoo_printer/elegoo_printer_progress.yaml
@@ -110,14 +110,14 @@ variables:
         else (device_entities(printer_device) | select('match', '^camera\.') | first))
        | default('', true) }}
 
-trigger:
-  - platform: state
+triggers:
+  - trigger: state
     entity_id: !input percent_complete_entity
-  - platform: state
+  - trigger: state
     entity_id: !input print_status_entity
-  - platform: state
+  - trigger: state
     entity_id: !input current_status_entity
-  - platform: state
+  - trigger: state
     entity_id: !input error_status_reason_entity
 
 condition: []


### PR DESCRIPTION
Thank you for the great work on this project!  I was able to easily add my new CC2 printer into HA.

When I tried to use the blueprint to create an automation, I was receiving an "error in describing trigger: Cannot read properties of undefined (reading 'includes')" on my 2026.2.3 Home Assistant installation each time the automation was triggered, and no notification was being sent.

Updating the blueprint to the modern template syntax (described here: https://community.home-assistant.io/t/deprecation-of-legacy-template-entities-in-2025-12/955562/1) fixed this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated automation trigger syntax to use the current standard format for improved maintainability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->