### PR TITLE
Fix issue #351: Split print speed presets by protocol version

### DIFF
--- a/custom_components/elegoo_printer/definitions.py
+++ b/custom_components/elegoo_printer/definitions.py
@@ -256,10 +256,29 @@ class ElegooPrinterNumberEntityDescription(NumberEntityDescription):
     set_value_fn: Callable[..., Coroutine[Any, Any, None]]
 
 
-PRINT_SPEED_PRESETS = {"Silent": 50, "Balanced": 100, "Sport": 150, "Ludicrous": 200}
+# Print speed presets for SDCP (WebSocket/MQTT) printers
+# These values align with the 160% speed clamp in websocket/mqtt clients
+PRINT_SPEED_PRESETS_SDCP = {
+    "Silent": 50,
+    "Balanced": 100,
+    "Sport": 130,
+    "Ludicrous": 160,
+}
+
+# Print speed presets for CC2 printers
+# These values map to discrete mode thresholds in the printer firmware
+PRINT_SPEED_PRESETS_CC2 = {
+    "Silent": 50,
+    "Balanced": 100,
+    "Sport": 150,
+    "Ludicrous": 200,
+}
 
 
-def _get_closest_print_speed_preset(speed_pct: int | None) -> str | None:
+def _get_closest_print_speed_preset(
+    speed_pct: int | None,
+    presets: dict[str, int] = PRINT_SPEED_PRESETS_SDCP,
+) -> str | None:
     """
     Find the closest matching print speed preset name for a given percentage.
 
@@ -267,8 +286,9 @@ def _get_closest_print_speed_preset(speed_pct: int | None) -> str | None:
     exactly match a preset (e.g., 160% when Ludicrous mode is selected but
     clamped by the printer firmware).
 
-    Arguments:
+    Args:
         speed_pct: The current print speed percentage from the printer.
+        presets: Dictionary mapping preset names to their percentage values.
 
     Returns:
         The name of the closest matching preset, or None if speed_pct is None.
@@ -281,7 +301,7 @@ def _get_closest_print_speed_preset(speed_pct: int | None) -> str | None:
     closest_name = None
     min_diff = float("inf")
 
-    for name, value in PRINT_SPEED_PRESETS.items():
+    for name, value in presets.items():
         diff = abs(value - speed_pct)
         if diff < min_diff:
             min_diff = diff
@@ -329,7 +349,9 @@ PRINTER_ATTRIBUTES_V3_ONLY: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         icon="mdi:camera",
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda printer_data: printer_data.attributes.num_video_stream_connected,  # noqa: E501
+        value_fn=lambda printer_data: (
+            printer_data.attributes.num_video_stream_connected
+        ),
     ),
     ElegooPrinterSensorEntityDescription(
         key="video_stream_max",
@@ -352,7 +374,9 @@ PRINTER_ATTRIBUTES_V3_ONLY: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         icon="mdi:cloud-check",
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda printer_data: printer_data.attributes.num_cloud_sdcp_services_connected,  # noqa: E501
+        value_fn=lambda printer_data: (
+            printer_data.attributes.num_cloud_sdcp_services_connected
+        ),
     ),
     ElegooPrinterSensorEntityDescription(
         key="max_cloud_sdcp_services_allowed",
@@ -360,7 +384,9 @@ PRINTER_ATTRIBUTES_V3_ONLY: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         icon="mdi:cloud-lock",
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda printer_data: printer_data.attributes.max_cloud_sdcp_services_allowed,  # noqa: E501
+        value_fn=lambda printer_data: (
+            printer_data.attributes.max_cloud_sdcp_services_allowed
+        ),
     ),
 )
 
@@ -373,18 +399,22 @@ PRINTER_ATTRIBUTES_BINARY_COMMON: tuple[
         name="USB Disk Status",
         icon="mdi:usb",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda printer_data: bool(printer_data.attributes.usb_disk_status)
-        if printer_data is not None
-        else False,
+        value_fn=lambda printer_data: (
+            bool(printer_data.attributes.usb_disk_status)
+            if printer_data is not None
+            else False
+        ),
     ),
     ElegooPrinterBinarySensorEntityDescription(
         key="sdcp_status",
         name="SDCP Status",
         icon="mdi:lan-connect",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda printer_data: bool(printer_data.attributes.sdcp_status)
-        if printer_data is not None
-        else False,
+        value_fn=lambda printer_data: (
+            bool(printer_data.attributes.sdcp_status)
+            if printer_data is not None
+            else False
+        ),
     ),
 )
 
@@ -459,12 +489,16 @@ PRINTER_ATTRIBUTES_RESIN: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda printer_data: printer_data.attributes.temp_of_uvled_max
-        if printer_data and printer_data.attributes
-        else None,
-        exists_fn=lambda printer_data: printer_data
-        and printer_data.attributes
-        and printer_data.attributes.temp_of_uvled_max > 0,
+        value_fn=lambda printer_data: (
+            printer_data.attributes.temp_of_uvled_max
+            if printer_data and printer_data.attributes
+            else None
+        ),
+        exists_fn=lambda printer_data: (
+            printer_data
+            and printer_data.attributes
+            and printer_data.attributes.temp_of_uvled_max > 0
+        ),
         entity_registry_enabled_default=False,
     ),
 )
@@ -505,18 +539,18 @@ PRINTER_STATUS_COMMON: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         name="End Time",
         icon="mdi:clock",
         device_class=SensorDeviceClass.TIMESTAMP,
-        value_fn=lambda printer_data: printer_data.current_job.end_time
-        if printer_data.current_job
-        else None,
+        value_fn=lambda printer_data: (
+            printer_data.current_job.end_time if printer_data.current_job else None
+        ),
     ),
     ElegooPrinterSensorEntityDescription(
         key="begin_time",
         name="Begin Time",
         icon="mdi:clock-start",
         device_class=SensorDeviceClass.TIMESTAMP,
-        value_fn=lambda printer_data: printer_data.current_job.begin_time
-        if printer_data.current_job
-        else None,
+        value_fn=lambda printer_data: (
+            printer_data.current_job.begin_time if printer_data.current_job else None
+        ),
     ),
     ElegooPrinterSensorEntityDescription(
         key="total_layers",
@@ -572,9 +606,13 @@ PRINTER_STATUS_COMMON: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         icon="mdi:file",
         device_class=SensorDeviceClass.ENUM,
         options=[status.name.lower() for status in ElegooMachineStatus],
-        value_fn=lambda printer_data: printer_data.status.current_status.name.lower()
-        if printer_data and printer_data.status and printer_data.status.current_status
-        else None,
+        value_fn=lambda printer_data: (
+            printer_data.status.current_status.name.lower()
+            if printer_data
+            and printer_data.status
+            and printer_data.status.current_status
+            else None
+        ),
     ),
     ElegooPrinterSensorEntityDescription(
         key="print_status",
@@ -583,12 +621,14 @@ PRINTER_STATUS_COMMON: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         icon="mdi:file",
         device_class=SensorDeviceClass.ENUM,
         options=[status.name.lower() for status in ElegooPrintStatus],
-        value_fn=lambda printer_data: printer_data.status.print_info.status.name.lower()
-        if printer_data
-        and printer_data.status
-        and printer_data.status.print_info
-        and printer_data.status.print_info.status
-        else None,
+        value_fn=lambda printer_data: (
+            printer_data.status.print_info.status.name.lower()
+            if printer_data
+            and printer_data.status
+            and printer_data.status.print_info
+            and printer_data.status.print_info.status
+            else None
+        ),
     ),
     ElegooPrinterSensorEntityDescription(
         key="print_error",
@@ -598,12 +638,14 @@ PRINTER_STATUS_COMMON: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,
         options=[error.name.lower() for error in ElegooPrintError],
-        value_fn=lambda printer_data: printer_data.status.print_info.error_number.name.lower()  # noqa: E501
-        if printer_data
-        and printer_data.status
-        and printer_data.status.print_info
-        and printer_data.status.print_info.error_number
-        else None,
+        value_fn=lambda printer_data: (
+            printer_data.status.print_info.error_number.name.lower()
+            if printer_data
+            and printer_data.status
+            and printer_data.status.print_info
+            and printer_data.status.print_info.error_number
+            else None
+        ),
     ),
     ElegooPrinterSensorEntityDescription(
         key="current_print_error_status_reason",
@@ -653,9 +695,11 @@ PRINTER_STATUS_RESIN_VAT_HEATER: tuple[ElegooPrinterSensorEntityDescription, ...
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value_fn=lambda printer_data: printer_data.status.temp_of_tank
-        if printer_data and printer_data.status
-        else None,
+        value_fn=lambda printer_data: (
+            printer_data.status.temp_of_tank
+            if printer_data and printer_data.status
+            else None
+        ),
     ),
     # --- Target Vat Temperature Sensor ---
     ElegooPrinterSensorEntityDescription(
@@ -665,9 +709,11 @@ PRINTER_STATUS_RESIN_VAT_HEATER: tuple[ElegooPrinterSensorEntityDescription, ...
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value_fn=lambda printer_data: printer_data.status.temp_target_tank
-        if printer_data and printer_data.status
-        else None,
+        value_fn=lambda printer_data: (
+            printer_data.status.temp_target_tank
+            if printer_data and printer_data.status
+            else None
+        ),
     ),
 )
 
@@ -681,9 +727,11 @@ PRINTER_STATUS_FDM: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value_fn=lambda printer_data: printer_data.status.temp_of_box
-        if printer_data and printer_data.status
-        else None,
+        value_fn=lambda printer_data: (
+            printer_data.status.temp_of_box
+            if printer_data and printer_data.status
+            else None
+        ),
     ),
     # --- Nozzle Temperature Sensor ---
     ElegooPrinterSensorEntityDescription(
@@ -693,9 +741,11 @@ PRINTER_STATUS_FDM: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value_fn=lambda printer_data: printer_data.status.temp_of_nozzle
-        if printer_data and printer_data.status
-        else None,
+        value_fn=lambda printer_data: (
+            printer_data.status.temp_of_nozzle
+            if printer_data and printer_data.status
+            else None
+        ),
     ),
     # --- Bed Temperature Sensor ---
     ElegooPrinterSensorEntityDescription(
@@ -705,9 +755,11 @@ PRINTER_STATUS_FDM: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value_fn=lambda printer_data: printer_data.status.temp_of_hotbed
-        if printer_data and printer_data.status
-        else None,
+        value_fn=lambda printer_data: (
+            printer_data.status.temp_of_hotbed
+            if printer_data and printer_data.status
+            else None
+        ),
     ),
     # --- Z Offset Sensor ---
     ElegooPrinterSensorEntityDescription(
@@ -719,9 +771,11 @@ PRINTER_STATUS_FDM: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfLength.MILLIMETERS,
         suggested_display_precision=4,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda printer_data: printer_data.status.z_offset
-        if printer_data and printer_data.status
-        else None,
+        value_fn=lambda printer_data: (
+            printer_data.status.z_offset
+            if printer_data and printer_data.status
+            else None
+        ),
     ),
     # --- Model Fan Speed Sensor ---
     ElegooPrinterSensorEntityDescription(
@@ -730,11 +784,13 @@ PRINTER_STATUS_FDM: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         icon="mdi:fan",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
-        value_fn=lambda printer_data: printer_data.status.current_fan_speed.model_fan
-        if printer_data
-        and printer_data.status
-        and printer_data.status.current_fan_speed
-        else None,
+        value_fn=lambda printer_data: (
+            printer_data.status.current_fan_speed.model_fan
+            if printer_data
+            and printer_data.status
+            and printer_data.status.current_fan_speed
+            else None
+        ),
     ),
     # --- Auxiliary Fan Speed Sensor ---
     ElegooPrinterSensorEntityDescription(
@@ -743,11 +799,13 @@ PRINTER_STATUS_FDM: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         icon="mdi:fan",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
-        value_fn=lambda printer_data: printer_data.status.current_fan_speed.auxiliary_fan  # noqa: E501
-        if printer_data
-        and printer_data.status
-        and printer_data.status.current_fan_speed
-        else None,
+        value_fn=lambda printer_data: (
+            printer_data.status.current_fan_speed.auxiliary_fan
+            if printer_data
+            and printer_data.status
+            and printer_data.status.current_fan_speed
+            else None
+        ),
     ),
     # --- Box/Enclosure Fan Speed Sensor ---
     ElegooPrinterSensorEntityDescription(
@@ -756,11 +814,13 @@ PRINTER_STATUS_FDM: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         icon="mdi:fan",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
-        value_fn=lambda printer_data: printer_data.status.current_fan_speed.box_fan
-        if printer_data
-        and printer_data.status
-        and printer_data.status.current_fan_speed
-        else None,
+        value_fn=lambda printer_data: (
+            printer_data.status.current_fan_speed.box_fan
+            if printer_data
+            and printer_data.status
+            and printer_data.status.current_fan_speed
+            else None
+        ),
     ),
     # --- Print Speed Percentage Sensor ---
     ElegooPrinterSensorEntityDescription(
@@ -769,9 +829,11 @@ PRINTER_STATUS_FDM: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         icon="mdi:speedometer",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
-        value_fn=lambda printer_data: printer_data.status.print_info.print_speed_pct
-        if printer_data and printer_data.status and printer_data.status.print_info
-        else None,
+        value_fn=lambda printer_data: (
+            printer_data.status.print_info.print_speed_pct
+            if printer_data and printer_data.status and printer_data.status.print_info
+            else None
+        ),
     ),
     # --- Current X Coordinate Sensor ---
     ElegooPrinterSensorEntityDescription(
@@ -818,9 +880,11 @@ PRINTER_STATUS_FDM_TOTAL_EXTRUSION: tuple[ElegooPrinterSensorEntityDescription, 
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfLength.MILLIMETERS,
         suggested_display_precision=2,
-        value_fn=lambda printer_data: printer_data.status.print_info.total_extrusion
-        if printer_data and printer_data.status and printer_data.status.print_info
-        else None,
+        value_fn=lambda printer_data: (
+            printer_data.status.print_info.total_extrusion
+            if printer_data and printer_data.status and printer_data.status.print_info
+            else None
+        ),
     ),
 )
 
@@ -836,9 +900,11 @@ PRINTER_STATUS_FDM_CURRENT_EXTRUSION: tuple[
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfLength.MILLIMETERS,
         suggested_display_precision=2,
-        value_fn=lambda printer_data: printer_data.status.print_info.current_extrusion
-        if printer_data and printer_data.status and printer_data.status.print_info
-        else None,
+        value_fn=lambda printer_data: (
+            printer_data.status.print_info.current_extrusion
+            if printer_data and printer_data.status and printer_data.status.print_info
+            else None
+        ),
     ),
 )
 
@@ -937,23 +1003,43 @@ PRINTER_FDM_LIGHTS: tuple[ElegooPrinterLightEntityDescription, ...] = (
     ElegooPrinterLightEntityDescription(
         key="second_light",
         name="Chamber Light",
-        value_fn=lambda light_status: light_status.second_light
-        if light_status
-        else None,
+        value_fn=lambda light_status: (
+            light_status.second_light if light_status else None
+        ),
     ),
 )
 
-PRINTER_SELECT_TYPES: tuple[ElegooPrinterSelectEntityDescription, ...] = (
+# Printer select types for SDCP (WebSocket/MQTT) printers - max 160% clamp
+PRINTER_SELECT_TYPES_V1V3: tuple[ElegooPrinterSelectEntityDescription, ...] = (
     ElegooPrinterSelectEntityDescription(
         key="print_speed",
         name="Print Speed",
         icon="mdi:speedometer",
-        options=list(PRINT_SPEED_PRESETS.keys()),
-        options_map=PRINT_SPEED_PRESETS,
+        options=list(PRINT_SPEED_PRESETS_SDCP.keys()),
+        options_map=PRINT_SPEED_PRESETS_SDCP,
         current_option_fn=lambda printer_data: _get_closest_print_speed_preset(
             printer_data.status.print_info.print_speed_pct
             if printer_data and printer_data.status and printer_data.status.print_info
-            else None
+            else None,
+            PRINT_SPEED_PRESETS_SDCP,
+        ),
+        select_option_fn=lambda api, value: api.async_set_print_speed(value),
+    ),
+)
+
+# Printer select types for CC2 protocol printers - discrete mode mapping
+PRINTER_SELECT_TYPES_CC2: tuple[ElegooPrinterSelectEntityDescription, ...] = (
+    ElegooPrinterSelectEntityDescription(
+        key="print_speed",
+        name="Print Speed",
+        icon="mdi:speedometer",
+        options=list(PRINT_SPEED_PRESETS_CC2.keys()),
+        options_map=PRINT_SPEED_PRESETS_CC2,
+        current_option_fn=lambda printer_data: _get_closest_print_speed_preset(
+            printer_data.status.print_info.print_speed_pct
+            if printer_data and printer_data.status and printer_data.status.print_info
+            else None,
+            PRINT_SPEED_PRESETS_CC2,
         ),
         select_option_fn=lambda api, value: api.async_set_print_speed(value),
     ),
@@ -1028,25 +1114,28 @@ PRINTER_FDM_BUTTONS: tuple[ElegooPrinterButtonEntityDescription, ...] = (
         name="Pause Print",
         action_fn=_pause_print_action,
         icon="mdi:pause",
-        available_fn=lambda client: client.printer_data.status.current_status
-        == ElegooMachineStatus.PRINTING,
+        available_fn=lambda client: (
+            client.printer_data.status.current_status == ElegooMachineStatus.PRINTING
+        ),
     ),
     ElegooPrinterButtonEntityDescription(
         key="resume_print",
         name="Resume Print",
         action_fn=_resume_print_action,
         icon="mdi:play",
-        available_fn=lambda client: client.printer_data.status.print_info.status
-        == ElegooPrintStatus.PAUSED,
+        available_fn=lambda client: (
+            client.printer_data.status.print_info.status == ElegooPrintStatus.PAUSED
+        ),
     ),
     ElegooPrinterButtonEntityDescription(
         key="stop_print",
         name="Stop Print",
         action_fn=_stop_print_action,
         icon="mdi:stop",
-        available_fn=lambda client: client.printer_data.status.current_status
-        in [ElegooMachineStatus.PRINTING]
-        or client.printer_data.status.print_info.status == ElegooPrintStatus.PAUSED,
+        available_fn=lambda client: (
+            client.printer_data.status.current_status in [ElegooMachineStatus.PRINTING]
+            or client.printer_data.status.print_info.status == ElegooPrintStatus.PAUSED
+        ),
     ),
 )
 
@@ -1056,32 +1145,36 @@ PRINTER_FDM_BUTTONS_V3_ONLY: tuple[ElegooPrinterButtonEntityDescription, ...] = 
         name="Home All",
         action_fn=_home_all_action,
         icon="mdi:home",
-        available_fn=lambda client: client.printer_data.status.current_status
-        == ElegooMachineStatus.IDLE,
+        available_fn=lambda client: (
+            client.printer_data.status.current_status == ElegooMachineStatus.IDLE
+        ),
     ),
     ElegooPrinterButtonEntityDescription(
         key="home_x",
         name="Home X",
         action_fn=_home_x_action,
         icon="mdi:axis-x-arrow",
-        available_fn=lambda client: client.printer_data.status.current_status
-        == ElegooMachineStatus.IDLE,
+        available_fn=lambda client: (
+            client.printer_data.status.current_status == ElegooMachineStatus.IDLE
+        ),
     ),
     ElegooPrinterButtonEntityDescription(
         key="home_y",
         name="Home Y",
         action_fn=_home_y_action,
         icon="mdi:axis-y-arrow",
-        available_fn=lambda client: client.printer_data.status.current_status
-        == ElegooMachineStatus.IDLE,
+        available_fn=lambda client: (
+            client.printer_data.status.current_status == ElegooMachineStatus.IDLE
+        ),
     ),
     ElegooPrinterButtonEntityDescription(
         key="home_z",
         name="Home Z",
         action_fn=_home_z_action,
         icon="mdi:axis-z-arrow",
-        available_fn=lambda client: client.printer_data.status.current_status
-        == ElegooMachineStatus.IDLE,
+        available_fn=lambda client: (
+            client.printer_data.status.current_status == ElegooMachineStatus.IDLE
+        ),
     ),
 )
 
@@ -1093,9 +1186,12 @@ FANS: tuple[ElegooPrinterFanEntityDescription, ...] = (
         supported_features=FanEntityFeature.SET_SPEED
         | FanEntityFeature.TURN_ON
         | FanEntityFeature.TURN_OFF,
-        value_fn=lambda printer_data: printer_data.status.current_fan_speed.model_fan
-        > 0,
-        percentage_fn=lambda printer_data: printer_data.status.current_fan_speed.model_fan,  # noqa: E501
+        value_fn=lambda printer_data: (
+            printer_data.status.current_fan_speed.model_fan > 0
+        ),
+        percentage_fn=lambda printer_data: (
+            printer_data.status.current_fan_speed.model_fan
+        ),
     ),
     ElegooPrinterFanEntityDescription(
         key="auxiliary_fan",
@@ -1104,9 +1200,12 @@ FANS: tuple[ElegooPrinterFanEntityDescription, ...] = (
         supported_features=FanEntityFeature.SET_SPEED
         | FanEntityFeature.TURN_ON
         | FanEntityFeature.TURN_OFF,
-        value_fn=lambda printer_data: printer_data.status.current_fan_speed.auxiliary_fan  # noqa: E501
-        > 0,
-        percentage_fn=lambda printer_data: printer_data.status.current_fan_speed.auxiliary_fan,  # noqa: E501
+        value_fn=lambda printer_data: (
+            printer_data.status.current_fan_speed.auxiliary_fan > 0
+        ),
+        percentage_fn=lambda printer_data: (
+            printer_data.status.current_fan_speed.auxiliary_fan
+        ),
     ),
     ElegooPrinterFanEntityDescription(
         key="box_fan",
@@ -1116,6 +1215,8 @@ FANS: tuple[ElegooPrinterFanEntityDescription, ...] = (
         | FanEntityFeature.TURN_ON
         | FanEntityFeature.TURN_OFF,
         value_fn=lambda printer_data: printer_data.status.current_fan_speed.box_fan > 0,
-        percentage_fn=lambda printer_data: printer_data.status.current_fan_speed.box_fan,  # noqa: E501
+        percentage_fn=lambda printer_data: (
+            printer_data.status.current_fan_speed.box_fan
+        ),
     ),
 )

--- a/custom_components/elegoo_printer/select.py
+++ b/custom_components/elegoo_printer/select.py
@@ -1,14 +1,31 @@
 """Platform for selecting Elegoo printer options."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from homeassistant.components.select import SelectEntity
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from custom_components.elegoo_printer.sdcp.models.enums import PrinterType
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .coordinator import ElegooDataUpdateCoordinator
-from .definitions import PRINTER_SELECT_TYPES, ElegooPrinterSelectEntityDescription
+from custom_components.elegoo_printer.sdcp.models.enums import (
+    PrinterType,
+    ProtocolVersion,
+)
+
+if TYPE_CHECKING:
+    from .api import ApiType
+    from .coordinator import ElegooDataUpdateCoordinator
+
+from .const import LOGGER
+from .definitions import (
+    PRINTER_SELECT_TYPES_CC2,
+    PRINTER_SELECT_TYPES_V1V3,
+    ElegooPrinterSelectEntityDescription,
+)
 from .entity import ElegooPrinterEntity
 
 
@@ -17,16 +34,36 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Asynchronously sets up Elegoo printer select entities in Home Assistant."""
-    coordinator: ElegooDataUpdateCoordinator = config_entry.runtime_data.coordinator
-    printer_type = coordinator.config_entry.runtime_data.api.printer.printer_type
+    """
+    Asynchronously sets up Elegoo printer select entities in Home Assistant.
 
-    if printer_type == PrinterType.FDM:
-        for description in PRINTER_SELECT_TYPES:
-            async_add_entities(
-                [ElegooPrintSpeedSelect(coordinator, description)],
-                update_before_add=True,
-            )
+    Supports FDM printers only. Different protocol versions use different speed presets:
+    - SDCP (WebSocket/MQTT): max 160%, presets at 50/100/130/160
+    - CC2: discrete modes, presets at 50/100/150/200
+    """
+    coordinator: ElegooDataUpdateCoordinator = config_entry.runtime_data.coordinator
+    api: ApiType = coordinator.config_entry.runtime_data.api
+    protocol_version = api.printer.protocol_version
+
+    if api.printer.printer_type.value != PrinterType.FDM.value:
+        LOGGER.debug(
+            "Print speed select only available for FDM printers, skipping setup"
+        )
+        return
+
+    descriptions: tuple[
+        ElegooPrinterSelectEntityDescription,
+        ...,
+    ] = (
+        PRINTER_SELECT_TYPES_CC2
+        if protocol_version == ProtocolVersion.CC2
+        else PRINTER_SELECT_TYPES_V1V3
+    )
+    for description in descriptions:
+        async_add_entities(
+            [ElegooPrintSpeedSelect(coordinator, description)],
+            update_before_add=True,
+        )
 
 
 class ElegooPrintSpeedSelect(ElegooPrinterEntity, SelectEntity):
@@ -52,8 +89,8 @@ class ElegooPrintSpeedSelect(ElegooPrinterEntity, SelectEntity):
         self._api = self.coordinator.config_entry.runtime_data.api
 
     @property
-    def current_option(self) -> None:
-        """Returns the current selected option."""
+    def current_option(self) -> str | None:
+        """Return the current select option."""
         if self.coordinator.data:
             return self.entity_description.current_option_fn(self.coordinator.data)
         return None


### PR DESCRIPTION
## Summary
Addresses GitHub issue #351 - SDCP printers clamp max speed to 160% but CC2 printers support discrete modes up to 200%.

## What changed
- Split `PRINT_SPEED_PRESETS` into two dictionaries:
  - `PRINT_SPEED_PRESETS_SDCP`: Silent=50%, Balanced=100%, Sport=130%, Ludicrous=160%
  - `PRINT_SPEED_PRESETS_CC2`: Silent=50%, Balanced=100%, Sport=150%, Ludicrous=200%

- Updated `_get_closest_print_speed_preset()` to accept optional `presets` parameter

- Created separate select type tuples:
  - `PRINTER_SELECT_TYPES_V1V3` (for SDCP protocol)
  - `PRINTER_SELECT_TYPES_CC2` (for CC2 protocol)

- Fixed TYPE_CHECKING imports in `select.py` using project's relative import pattern

## Testing
All 136 tests pass ✅

Closes: https://github.com/danielcherubini/elegoo-homeassistant/issues/351

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added printer model-specific print speed presets optimized for SDCP (V1/V3) and CC2 printers.
  * Implemented automatic protocol detection to ensure correct settings are applied during setup.

* **Bug Fixes**
  * Enhanced reliability by improving handling of missing or incomplete printer data states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->