### PR TITLE
Status-transition queue for cc2 print status (#364)

### DIFF
--- a/custom_components/elegoo_printer/cc2/client.py
+++ b/custom_components/elegoo_printer/cc2/client.py
@@ -16,6 +16,7 @@ import contextlib
 import json
 import secrets
 import time
+from collections import deque
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
@@ -60,6 +61,7 @@ from .const import (
     CC2_MQTT_KEEPALIVE,
     CC2_MQTT_PORT,
     CC2_MQTT_USERNAME,
+    CC2_PRINT_STATUS_TRANSITION_QUEUE_MAX,
     CC2_REG_OK,
     CC2_REG_TOO_MANY_CLIENTS,
     CC2_REGISTRATION_TIMEOUT,
@@ -69,7 +71,10 @@ from .models import CC2StatusMapper
 
 if TYPE_CHECKING:
     from custom_components.elegoo_printer.sdcp.models.enums import ElegooFan
-    from custom_components.elegoo_printer.sdcp.models.status import LightStatus
+    from custom_components.elegoo_printer.sdcp.models.status import (
+        LightStatus,
+        PrinterStatus,
+    )
 
 
 class ElegooCC2Client:
@@ -152,6 +157,10 @@ class ElegooCC2Client:
         self._cached_status: dict[str, Any] = {}
         self._status_sequence = 0
         self._non_continuous_count = 0
+        # Queued snapshots: each distinct print_info.status between HA polls
+        self._print_status_transition_queue: deque[PrinterStatus] = deque(
+            maxlen=CC2_PRINT_STATUS_TRANSITION_QUEUE_MAX
+        )
 
         # Registration tracking
         self._registration_event: asyncio.Event | None = None
@@ -368,6 +377,23 @@ class ElegooCC2Client:
         self.mqtt_client = None
         self._is_connected = False
         self._is_registered = False
+        self._print_status_transition_queue.clear()
+
+    def consume_print_status_transition_queue(self) -> list[PrinterStatus]:
+        """
+        Drain and return all queued PrinterStatus snapshots for distinct print_info.status changes.
+
+        Each snapshot was captured when the mapped print sub-status changed. The data
+        coordinator replays them so Home Assistant records transient values that would
+        otherwise be overwritten before the next poll (for example COMPLETE before IDLE).
+
+        Returns:
+            list[PrinterStatus]: Snapshots in the order the transitions occurred.
+
+        """  # noqa: E501
+        snapshots = list(self._print_status_transition_queue)
+        self._print_status_transition_queue.clear()
+        return snapshots
 
     async def _subscribe_to_topics(self) -> None:
         """Subscribe to all required MQTT topics."""
@@ -684,10 +710,14 @@ class ElegooCC2Client:
     def _update_printer_status(self) -> None:
         """Update printer_data.status from cached status."""
         try:
+            previous_print_status = self.printer_data.status.print_info.status
             # Map CC2 status format to PrinterStatus
             mapped_status = CC2StatusMapper.map_status(
                 self._cached_status, self.printer.printer_type
             )
+            new_print_status = mapped_status.print_info.status
+            if new_print_status != previous_print_status:
+                self._print_status_transition_queue.append(deepcopy(mapped_status))
             self.printer_data.status = mapped_status
             self.logger.debug(
                 "Updated printer status: %s",

--- a/custom_components/elegoo_printer/cc2/const.py
+++ b/custom_components/elegoo_printer/cc2/const.py
@@ -28,6 +28,8 @@ CC2_COMMAND_TIMEOUT = 10  # seconds
 
 # Delta status settings
 CC2_MAX_NON_CONTINUOUS_EVENTS = 5  # Re-request full status after this many gaps
+# Max distinct print-status snapshots queued for HA replay (MQTT bursts)
+CC2_PRINT_STATUS_TRANSITION_QUEUE_MAX = 32
 
 # Topic patterns
 # elegoo/<sn>/api_register - Registration request

--- a/custom_components/elegoo_printer/cc2/tests/__init__.py
+++ b/custom_components/elegoo_printer/cc2/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for CC2 client and protocol helpers."""

--- a/custom_components/elegoo_printer/cc2/tests/test_print_status_queue.py
+++ b/custom_components/elegoo_printer/cc2/tests/test_print_status_queue.py
@@ -1,0 +1,89 @@
+"""
+Tests for CC2 print_info.status transition queue (HA replay).
+
+These tests set _cached_status and call _update_printer_status() to mimic the
+post-merge state MQTT handling would leave, without standing up a broker.
+"""
+
+from __future__ import annotations
+
+from custom_components.elegoo_printer.cc2.client import ElegooCC2Client
+from custom_components.elegoo_printer.cc2.const import (
+    CC2_STATUS_IDLE,
+    CC2_STATUS_PRINTING,
+    CC2_SUBSTATUS_PRINTING,
+    CC2_SUBSTATUS_PRINTING_COMPLETED,
+)
+from custom_components.elegoo_printer.sdcp.models.enums import (
+    ElegooPrintStatus,
+    PrinterType,
+)
+from custom_components.elegoo_printer.sdcp.models.printer import Printer
+
+
+def _client() -> ElegooCC2Client:
+    printer = Printer()
+    printer.printer_type = PrinterType.FDM
+    return ElegooCC2Client("192.168.1.1", "TESTSN", printer=printer)
+
+
+def test_queue_records_printing_complete_idle_sequence() -> None:
+    """Rapid MQTT-style deltas must enqueue each distinct ElegooPrintStatus."""
+    client = _client()
+    base = {"print_status": {}}
+
+    def apply_delta(sub_status: int, machine_status: int) -> None:
+        client._cached_status = {  # noqa: SLF001
+            **base,
+            "machine_status": {
+                "status": machine_status,
+                "sub_status": sub_status,
+            },
+        }
+        client._update_printer_status()  # noqa: SLF001
+
+    apply_delta(CC2_SUBSTATUS_PRINTING, CC2_STATUS_PRINTING)
+    apply_delta(CC2_SUBSTATUS_PRINTING_COMPLETED, CC2_STATUS_PRINTING)
+    apply_delta(0, CC2_STATUS_IDLE)
+
+    pending = client.consume_print_status_transition_queue()
+    assert [s.print_info.status for s in pending] == [
+        ElegooPrintStatus.PRINTING,
+        ElegooPrintStatus.COMPLETE,
+        ElegooPrintStatus.IDLE,
+    ]
+
+
+def test_no_queue_when_print_status_unchanged() -> None:
+    """Repeated mapping with the same print_info.status must not enqueue again."""
+    client = _client()
+
+    def apply_delta(sub_status: int, machine_status: int) -> None:
+        client._cached_status = {  # noqa: SLF001
+            "print_status": {},
+            "machine_status": {
+                "status": machine_status,
+                "sub_status": sub_status,
+            },
+        }
+        client._update_printer_status()  # noqa: SLF001
+
+    apply_delta(CC2_SUBSTATUS_PRINTING, CC2_STATUS_PRINTING)
+    client.consume_print_status_transition_queue()
+    apply_delta(CC2_SUBSTATUS_PRINTING, CC2_STATUS_PRINTING)
+    assert client.consume_print_status_transition_queue() == []
+
+
+def test_consume_clears_queue() -> None:
+    """consume_print_status_transition_queue must return items once then yield empty."""
+    client = _client()
+    client._cached_status = {  # noqa: SLF001
+        "print_status": {},
+        "machine_status": {
+            "status": CC2_STATUS_PRINTING,
+            "sub_status": CC2_SUBSTATUS_PRINTING,
+        },
+    }
+    client._update_printer_status()  # noqa: SLF001
+    assert len(client.consume_print_status_transition_queue()) == 1
+    assert client.consume_print_status_transition_queue() == []

--- a/custom_components/elegoo_printer/coordinator.py
+++ b/custom_components/elegoo_printer/coordinator.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from custom_components.elegoo_printer.cc2.client import ElegooCC2Client
 from custom_components.elegoo_printer.const import LOGGER
 from custom_components.elegoo_printer.sdcp.exceptions import (
     ElegooPrinterConnectionError,
@@ -98,6 +99,8 @@ class ElegooDataUpdateCoordinator(DataUpdateCoordinator):
                     # Rate-limit even on failure to avoid hammering the endpoint
                     self._last_canvas_check = now
 
+            self._replay_cc2_print_status_transitions()
+
             self.online = True
             if self.update_interval != timedelta(seconds=2):
                 self.update_interval = timedelta(seconds=2)
@@ -130,6 +133,30 @@ class ElegooDataUpdateCoordinator(DataUpdateCoordinator):
             )
             msg = f"Unexpected Error: {e.strerror}"
             raise UpdateFailed(msg) from e
+
+    def _replay_cc2_print_status_transitions(self) -> None:
+        """
+        Replay queued CC2 print status snapshots so Home Assistant sees each transition.
+
+        CC2 MQTT can deliver several status deltas within seconds; the client keeps only the
+        latest merged state. After a normal data fetch, this drains the client's transition
+        queue, calls async_set_updated_data for each snapshot, then restores the live status
+        from the client so printer_data stays authoritative.
+
+        Returns:
+            None
+
+        """  # noqa: E501
+        api = self.config_entry.runtime_data.api
+        if not isinstance(api.client, ElegooCC2Client):
+            return
+        pending = api.client.consume_print_status_transition_queue()
+        if not pending:
+            return
+        for status_snapshot in pending:
+            api.printer_data.status = status_snapshot
+            self.async_set_updated_data(api.printer_data)
+        api.printer_data.status = api.client.printer_data.status
 
     def generate_unique_id(self, key: str) -> str:
         """

--- a/custom_components/elegoo_printer/coordinator.py
+++ b/custom_components/elegoo_printer/coordinator.py
@@ -153,10 +153,11 @@ class ElegooDataUpdateCoordinator(DataUpdateCoordinator):
         pending = api.client.consume_print_status_transition_queue()
         if not pending:
             return
+        original_status = api.printer_data.status
         for status_snapshot in pending:
             api.printer_data.status = status_snapshot
             self.async_set_updated_data(api.printer_data)
-        api.printer_data.status = api.client.printer_data.status
+        api.printer_data.status = original_status
 
     def generate_unique_id(self, key: str) -> str:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ max-complexity = 25
 "custom_components/elegoo_printer/sdcp/tests/*.py" = ["S101"]
 "custom_components/elegoo_printer/websocket/tests/*.py" = ["S101"]
 "custom_components/elegoo_printer/tests/*.py" = ["S101"]
+"custom_components/elegoo_printer/cc2/tests/*.py" = ["S101"]
 
 [tool.pytest.ini_options]
 pythonpath = [


### PR DESCRIPTION
Cause
The Print Status sensor reads printer_data.status.print_info.status (ElegooPrintStatus). CC2 applies several MQTT deltas in a row, so by the next coordinator poll only the last value (often idle) remained; complete never appeared in HA’s state history, so automations on complete did not run.

Implements a status-transition queue so rapid CC2 MQTT deltas (PRINTING → COMPLETE → IDLE) surface as separate HA state updates.

Automations should now see a distinct complete (and then idle) state on the Print Status entity, even when those MQTT updates land in the same second.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved printer status handling to capture and replay rapid status transitions during network or MQTT bursts so users see the full, ordered sequence of print-state changes (including across reconnects).

* **Tests**
  * Added tests covering queuing, idempotency, and consumption behavior for print-status transitions to ensure reliable playback and clear-on-consume semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->