### PR TITLE
Fix stale thumbnail when reprinting same filename with new colors

### DIFF
--- a/custom_components/elegoo_printer/cc2/client.py
+++ b/custom_components/elegoo_printer/cc2/client.py
@@ -759,9 +759,8 @@ class ElegooCC2Client:
         except Exception:
             self.logger.exception("Failed to map CC2 status to PrinterStatus")
 
-    @staticmethod
-    def _clear_stale_file_detail_keys(file_info: dict[str, Any]) -> None:
-        """Drop proxy + MQTT file-detail cache so a new job refetches."""
+    def _clear_stale_caches(self, filename: str, file_info: dict[str, Any]) -> None:
+        """Drop proxy, MQTT file-detail, and thumbnail caches for a re-used filename."""
         for key in (
             "proxy_filament",
             "proxy_filament_status",
@@ -771,6 +770,8 @@ class ElegooCC2Client:
             "TotalLayers",
         ):
             file_info.pop(key, None)
+        file_thumbnails = self._integration_data.get("_file_thumbnails", {})
+        file_thumbnails.pop(filename, None)
 
     def _update_current_job(self) -> None:
         """Update current job from print status data."""
@@ -791,8 +792,8 @@ class ElegooCC2Client:
         # for this file so proxy + MQTT file-detail enrichment refetch for the
         # new print (task_id is unique per job).
         is_new_task = self.printer_data.print_history.get(task_id) is None
-        if is_new_task and file_info:
-            self._clear_stale_file_detail_keys(file_info)
+        if is_new_task:
+            self._clear_stale_caches(filename, file_info)
 
         # Check enrichment data (TotalLayers, total_filament_used,
         # color_map, print_time)

--- a/custom_components/elegoo_printer/cc2/tests/test_update_current_job_cache_invalidation.py
+++ b/custom_components/elegoo_printer/cc2/tests/test_update_current_job_cache_invalidation.py
@@ -100,6 +100,64 @@ class TestUpdateCurrentJobCacheInvalidation:
         assert details["proxy_filament_status"] == "success"
         client._request_proxy_filament_background.assert_not_called()
 
+    def test_new_task_clears_stale_thumbnail(self) -> None:
+        """New task_id with same filename drops cached thumbnail."""
+        client = _client_with_proxy()
+        fn = "CC2_Model.gcode"
+        client._integration_data["_file_thumbnails"] = {
+            fn: "data:image/png;base64,oldThumbnailData",
+        }
+        client._integration_data["_file_details"] = {
+            fn: {"TotalLayers": 500},
+        }
+        client._cached_status = {
+            "print_status": {
+                "uuid": "task-new-thumb-001",
+                "filename": fn,
+                "total_layer": 100,
+            },
+        }
+        client._request_proxy_filament_background = MagicMock()
+        client._request_file_detail_background = MagicMock()
+        client._request_file_thumbnail_background = MagicMock()
+
+        client._update_current_job()
+
+        assert fn not in client._integration_data["_file_thumbnails"]
+        client._request_file_thumbnail_background.assert_called_once_with(fn)
+
+    def test_same_task_keeps_cached_thumbnail(self) -> None:
+        """Same task_id must not clear thumbnail between MQTT updates."""
+        client = _client_with_proxy()
+        fn = "CC2_Model.gcode"
+        tid = "task-same-thumb-001"
+        old_thumb = "data:image/png;base64,existingThumb"
+        client.printer_data.print_history[tid] = PrintHistoryDetail(
+            {"TaskId": tid, "TaskName": fn},
+        )
+        client._integration_data["_file_thumbnails"] = {fn: old_thumb}
+        client._integration_data["_file_details"] = {
+            fn: {
+                "proxy_filament": OLD_PROXY,
+                "proxy_filament_status": "success",
+            },
+        }
+        client._cached_status = {
+            "print_status": {
+                "uuid": tid,
+                "filename": fn,
+                "total_layer": 50,
+            },
+        }
+        client._request_proxy_filament_background = MagicMock()
+        client._request_file_detail_background = MagicMock()
+        client._request_file_thumbnail_background = MagicMock()
+
+        client._update_current_job()
+
+        assert client._integration_data["_file_thumbnails"][fn] == old_thumb
+        client._request_file_thumbnail_background.assert_not_called()
+
     def test_new_task_empty_file_info_still_schedules_proxy_fetch(self) -> None:
         """New task with no prior file_info should request proxy data once."""
         client = _client_with_proxy()


### PR DESCRIPTION
When the same `.gcode` filename was sent to the printer multiple times with different color profiles, the notification image kept showing colors from the first print. The cached thumbnail in `_integration_data["_file_thumbnails"]` was keyed by filename and never evicted on a new task, so the old image was reused instead of fetching a fresh one from the printer. 

**Changes:**

- **`cc2/client.py`**: Renamed `_clear_stale_file_detail_keys` to `_clear_stale_caches` and expanded it to also evict the thumbnail cache entry for the filename. Called unconditionally on `is_new_task` (not gated on `file_info` being truthy) so thumbnails are cleared even if file details weren't previously cached.
- **`cc2/tests/test_update_current_job_cache_invalidation.py`**: Added `test_new_task_clears_stale_thumbnail` and `test_same_task_keeps_cached_thumbnail` to verify eviction on new task and preservation within the same task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache management when printer tasks are updated to prevent displaying outdated file information and cached thumbnails.
  * Thumbnail cache is now properly invalidated when the same filename is used across different tasks.

* **Tests**
  * Added test coverage to verify cache invalidation behavior for thumbnails when new tasks are detected and when tasks remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->