### PR TITLE
fix: sync live attributes to Printer object on each update

### DIFF
--- a/custom_components/elegoo_printer/cc2/client.py
+++ b/custom_components/elegoo_printer/cc2/client.py
@@ -1091,6 +1091,8 @@ class ElegooCC2Client:
             # Map CC2 attributes to PrinterAttributes
             mapped_attrs = CC2StatusMapper.map_attributes(attrs_data)
             self.printer_data.attributes = mapped_attrs
+            if self.printer:
+                self.printer.sync_from_attributes(mapped_attrs)
         except Exception:
             self.logger.exception("Failed to map CC2 attributes")
 

--- a/custom_components/elegoo_printer/mqtt/client.py
+++ b/custom_components/elegoo_printer/mqtt/client.py
@@ -886,6 +886,8 @@ class ElegooMqttClient:
             self.logger.debug("PrinterAttributes.from_json() succeeded")
             self.printer_data.attributes = printer_attributes
             self.logger.debug("Assigned printer_data.attributes successfully")
+            if self.printer:
+                self.printer.sync_from_attributes(printer_attributes)
         except Exception:
             self.logger.exception("Exception in _attributes_handler")
 

--- a/custom_components/elegoo_printer/sdcp/models/printer.py
+++ b/custom_components/elegoo_printer/sdcp/models/printer.py
@@ -305,6 +305,59 @@ class Printer:
         data.pop("cc2_access_code", None)
         return data
 
+    def sync_from_attributes(self, attrs: PrinterAttributes) -> bool:
+        """
+        Sync live attributes from PrinterAttributes to this Printer instance.
+
+        Copies firmware, model, name, and brand from attrs if the source value
+        is truthy (non-empty string) and differs from the current value.
+        After syncing, re-derives dependent flags if model or firmware changed.
+
+        Args:
+            attrs: PrinterAttributes instance containing live attribute values.
+
+        Returns:
+            True if any field was updated, False otherwise.
+
+        """
+        updated = False
+
+        # Track which fields changed for re-derivation
+        model_changed = False
+        firmware_changed = False
+
+        # Sync firmware
+        if attrs.firmware_version and attrs.firmware_version != self.firmware:
+            self.firmware = attrs.firmware_version
+            firmware_changed = True
+            updated = True
+
+        # Sync model
+        if attrs.machine_name and attrs.machine_name != self.model:
+            self.model = attrs.machine_name
+            model_changed = True
+            updated = True
+
+        # Sync name
+        if attrs.name and attrs.name != self.name:
+            self.name = attrs.name
+            updated = True
+
+        # Sync brand
+        if attrs.brand_name and attrs.brand_name != self.brand:
+            self.brand = attrs.brand_name
+            updated = True
+
+        # Re-derive dependent flags if model or firmware changed
+        if model_changed or firmware_changed:
+            self.printer_type = PrinterType.from_model(self.model)
+            self.open_centauri = self._is_open_centauri(self.model, self.firmware)
+
+        if model_changed:
+            self.has_vat_heater = self._has_vat_heater(self.model)
+
+        return updated
+
     @classmethod
     def from_dict(
         cls,

--- a/custom_components/elegoo_printer/sdcp/models/tests/test_printer.py
+++ b/custom_components/elegoo_printer/sdcp/models/tests/test_printer.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from custom_components.elegoo_printer.sdcp.models.attributes import PrinterAttributes
+from custom_components.elegoo_printer.sdcp.models.enums import PrinterType
 from custom_components.elegoo_printer.sdcp.models.printer import Printer
 
 
@@ -51,3 +53,142 @@ class TestOpenCentauriDetection:
             f"Expected {expected} for model='{model}' firmware='{firmware}', "
             f"got {result}"
         )
+
+
+class TestSyncFromAttributes:
+    """Test Printer.sync_from_attributes() method."""
+
+    def test_sync_from_attributes_updates_firmware(self) -> None:
+        """Verify firmware is updated from attrs."""
+        printer = Printer()
+        printer.firmware = "V1.0.0"
+
+        attrs = PrinterAttributes({"Attributes": {"FirmwareVersion": "V2.0.0"}})
+        result = printer.sync_from_attributes(attrs)
+
+        assert result is True  # noqa: S101
+        assert printer.firmware == "V2.0.0"  # noqa: S101
+
+    def test_sync_from_attributes_skips_empty_values(self) -> None:
+        """Verify empty strings don't overwrite existing values."""
+        printer = Printer()
+        printer.firmware = "V1.0.0"
+        printer.model = "Saturn 3"
+        printer.name = "My Printer"
+        printer.brand = "Elegoo"
+
+        attrs = PrinterAttributes(
+            {"Attributes": {"FirmwareVersion": "", "MachineName": ""}}
+        )
+        result = printer.sync_from_attributes(attrs)
+
+        assert result is False  # noqa: S101
+        assert printer.firmware == "V1.0.0"  # noqa: S101
+        assert printer.model == "Saturn 3"  # noqa: S101
+        assert printer.name == "My Printer"  # noqa: S101
+        assert printer.brand == "Elegoo"  # noqa: S101
+
+    def test_sync_from_attributes_skips_unchanged_values(self) -> None:
+        """Verify returning False when nothing changed."""
+        printer = Printer()
+        printer.firmware = "V1.0.0"
+        printer.model = "Saturn 3"
+        printer.name = "My Printer"
+        printer.brand = "Elegoo"
+
+        attrs = PrinterAttributes(
+            {
+                "Attributes": {
+                    "FirmwareVersion": "V1.0.0",
+                    "MachineName": "Saturn 3",
+                    "Name": "My Printer",
+                    "BrandName": "Elegoo",
+                }
+            }
+        )
+        result = printer.sync_from_attributes(attrs)
+
+        assert result is False  # noqa: S101
+
+    def test_sync_from_attributes_rederives_printer_type(self) -> None:
+        """Verify printer_type updates when model changes."""
+        printer = Printer()
+        printer.model = "Saturn 3"
+        printer.printer_type = PrinterType.FDM
+
+        attrs = PrinterAttributes({"Attributes": {"MachineName": "Saturn 4 Ultra 16K"}})
+        result = printer.sync_from_attributes(attrs)
+
+        assert result is True  # noqa: S101
+        assert printer.model == "Saturn 4 Ultra 16K"  # noqa: S101
+        assert printer.printer_type == PrinterType.RESIN  # noqa: S101
+
+    def test_sync_from_attributes_rederives_open_centauri(self) -> None:
+        """Verify open_centauri flag updates when firmware changes."""
+        printer = Printer()
+        printer.model = "Centauri Carbon"
+        printer.firmware = "V0.1.0"
+        printer.open_centauri = False
+
+        attrs = PrinterAttributes({"Attributes": {"FirmwareVersion": "V0.1.0 O"}})
+        result = printer.sync_from_attributes(attrs)
+
+        assert result is True  # noqa: S101
+        assert printer.firmware == "V0.1.0 O"  # noqa: S101
+        assert printer.open_centauri is True  # noqa: S101
+
+    def test_sync_from_attributes_rederives_has_vat_heater(self) -> None:
+        """Verify has_vat_heater flag updates when model changes."""
+        printer = Printer()
+        printer.model = "Saturn 3"
+        printer.has_vat_heater = False
+
+        attrs = PrinterAttributes({"Attributes": {"MachineName": "Saturn 4 Ultra 16K"}})
+        result = printer.sync_from_attributes(attrs)
+
+        assert result is True  # noqa: S101
+        assert printer.model == "Saturn 4 Ultra 16K"  # noqa: S101
+        assert printer.has_vat_heater is True  # noqa: S101
+
+    def test_sync_from_attributes_syncs_all_fields(self) -> None:
+        """Verify model, name, brand are also synced."""
+        printer = Printer()
+        printer.firmware = "V1.0.0"
+        printer.model = "Old Model"
+        printer.name = "Old Name"
+        printer.brand = "Old Brand"
+
+        attrs = PrinterAttributes(
+            {
+                "Attributes": {
+                    "FirmwareVersion": "V2.0.0",
+                    "MachineName": "New Model",
+                    "Name": "New Name",
+                    "BrandName": "New Brand",
+                }
+            }
+        )
+        result = printer.sync_from_attributes(attrs)
+
+        assert result is True  # noqa: S101
+        assert printer.firmware == "V2.0.0"  # noqa: S101
+        assert printer.model == "New Model"  # noqa: S101
+        assert printer.name == "New Name"  # noqa: S101
+        assert printer.brand == "New Brand"  # noqa: S101
+
+    def test_sync_from_attributes_skips_all_empty_attrs(self) -> None:
+        """Verify PrinterAttributes({}) with no Attributes key skips everything."""
+        printer = Printer()
+        printer.firmware = "V1.0.0"
+        printer.model = "Saturn 3"
+        printer.name = "My Printer"
+        printer.brand = "Elegoo"
+
+        attrs = PrinterAttributes({})
+        result = printer.sync_from_attributes(attrs)
+
+        assert result is False  # noqa: S101
+        assert printer.firmware == "V1.0.0"  # noqa: S101
+        assert printer.model == "Saturn 3"  # noqa: S101
+        assert printer.name == "My Printer"  # noqa: S101
+        assert printer.brand == "Elegoo"  # noqa: S101

--- a/custom_components/elegoo_printer/websocket/client.py
+++ b/custom_components/elegoo_printer/websocket/client.py
@@ -711,6 +711,8 @@ class ElegooPrinterClient:
             self.logger.info(msg)
         printer_attributes = PrinterAttributes.from_json(json.dumps(data))
         self.printer_data.attributes = printer_attributes
+        if self.printer:
+            self.printer.sync_from_attributes(printer_attributes)
 
     def _print_history_handler(self, data_data: dict[str, Any]) -> None:
         """Parse and updates the printer's print history details from the data."""

--- a/docs/plans/2025-06-25-sync-printer-attributes.md
+++ b/docs/plans/2025-06-25-sync-printer-attributes.md
@@ -1,0 +1,187 @@
+# Sync Live Attributes to Printer Object
+
+**Goal:** Fix stale firmware (and model/name/brand) by syncing live MQTT/WebSocket attributes to the `Printer` object whenever attributes are received.
+
+**Architecture:** Add `Printer.sync_from_attributes(PrinterAttributes) -> bool` that copies live values with guards against empty/unchanged data and re-derives dependent flags (`open_centauri`, `has_vat_heater`). Call from both CC2 and WebSocket attribute handlers.
+
+**Tech Stack:** Python, Home Assistant custom component
+
+---
+
+### Task 1: Add `Printer.sync_from_attributes()` method
+
+**Context:**
+`Printer.firmware` (and `model`, `name`, `brand`) is set once from the stored config entry via `Printer.from_dict()` and never refreshed. After the user updates printer firmware, the integration reads the stale value, causing incorrect firmware update checks and stale device info in Home Assistant. This task adds a method to sync live attributes with guards and dependent flag re-derivation.
+
+**Files:**
+- Modify: `custom_components/elegoo_printer/sdcp/models/printer.py`
+- Test: `custom_components/elegoo_printer/sdcp/models/tests/test_printer.py`
+
+**What to implement:**
+- Add `sync_from_attributes(self, attrs: PrinterAttributes) -> bool` method to the `Printer` class
+- The method copies these fields from `PrinterAttributes` to `Printer`:
+  - `attrs.firmware_version` → `self.firmware`
+  - `attrs.machine_name` → `self.model`
+  - `attrs.name` → `self.name`
+  - `attrs.brand_name` → `self.brand`
+- Only overwrite when source value is truthy (non-empty string) AND differs from current value
+- After syncing, if `model` or `firmware` changed, re-derive:
+  - `self.printer_type = PrinterType.from_model(self.model)`
+  - `self.open_centauri = self._is_open_centauri(self.model, self.firmware)`
+  - `self.has_vat_heater = self._has_vat_heater(self.model)`
+- Return `True` if any field was updated, `False` otherwise
+- Place `sync_from_attributes` immediately after `to_dict_safe()` and before `from_dict()`
+- Do NOT modify `from_dict()` or any other existing method
+
+**Steps:**
+- [ ] Write unit tests in `custom_components/elegoo_printer/sdcp/models/tests/test_printer.py`:
+  - `test_sync_from_attributes_updates_firmware` — verify firmware is updated from attrs
+  - `test_sync_from_attributes_skips_empty_values` — verify empty strings don't overwrite existing values
+  - `test_sync_from_attributes_skips_unchanged_values` — verify returning False when nothing changed
+  - `test_sync_from_attributes_rederives_open_centauri` — verify open_centauri flag updates when firmware changes
+  - `test_sync_from_attributes_rederives_printer_type` — verify printer_type updates when model changes
+  - `test_sync_from_attributes_rederives_open_centauri` — verify open_centauri flag updates when firmware changes. Pre-condition: `printer.model = "Centauri Carbon"`, `printer.firmware = "V0.1.0"` (no O marker). Sync attrs with `FirmwareVersion = "V0.1.0 O"`. Verify `open_centauri` becomes `True`.
+  - `test_sync_from_attributes_rederives_has_vat_heater` — verify has_vat_heater flag updates when model changes. Pre-condition: `printer.model = "Saturn 3"` (no vat heater). Sync attrs with `MachineName = "Saturn 4 Ultra 16K"`. Verify `has_vat_heater` becomes `True`.
+  - `test_sync_from_attributes_syncs_all_fields` — verify model, name, brand are also synced
+  - `test_sync_from_attributes_skips_all_empty_attrs` — create `PrinterAttributes({})` (no Attributes key, all fields default to `""`), verify nothing changes and returns `False`
+  - Use `PrinterAttributes({"Attributes": {...}})` to create test attribute objects
+  - Use `Printer()` to create empty printer instances, then set fields manually
+- [ ] Run `make test` — confirm new tests fail (method doesn't exist yet)
+- [ ] Implement `sync_from_attributes()` in `custom_components/elegoo_printer/sdcp/models/printer.py`
+- [ ] Run `make test` — confirm all tests pass
+- [ ] Run `make format` — confirm code is formatted
+- [ ] Run `make lint` — confirm no lint errors
+- [ ] Commit with message: "feat: add Printer.sync_from_attributes() to refresh live attributes"
+
+**Acceptance criteria:**
+- [ ] `sync_from_attributes()` updates firmware/model/name/brand from non-empty attrs
+- [ ] `sync_from_attributes()` does NOT overwrite with empty strings
+- [ ] `sync_from_attributes()` does NOT overwrite when value is unchanged
+- [ ] `open_centauri` is re-derived when model or firmware changes
+- [ ] `has_vat_heater` is re-derived when model changes
+- [ ] Returns correct bool for changed/unchanged
+- [ ] All tests pass, lint clean
+
+---
+
+### Task 2: Call sync from CC2 attribute handler
+
+**Context:**
+The CC2 client receives attributes via MQTT in `_handle_attributes()`. Currently it maps the CC2 nested format to `PrinterAttributes` and stores in `printer_data.attributes`, but never syncs to `self.printer`. This means `self.printer.firmware` remains stale. Adding a one-line call to `sync_from_attributes()` fixes this.
+
+**Files:**
+- Modify: `custom_components/elegoo_printer/cc2/client.py`
+
+**What to implement:**
+- In `_handle_attributes(self, attrs_data: dict[str, Any])`, after the line `self.printer_data.attributes = mapped_attrs`, add:
+  ```python
+  if self.printer:
+      self.printer.sync_from_attributes(mapped_attrs)
+  ```
+- Guard with `if self.printer:` to avoid crash during disconnection race conditions
+- This is inside the existing `try` block, same indentation level as the `self.printer_data.attributes = mapped_attrs` line
+- Do NOT modify any other code in this file
+
+**Steps:**
+- [ ] Add the `self.printer.sync_from_attributes(mapped_attrs)` call in `cc2/client.py` `_handle_attributes()`
+- [ ] Run `make format` — confirm code is formatted
+- [ ] Run `make lint` — confirm no lint errors
+- [ ] Run `make test` — confirm no regressions
+- [ ] Commit with message: "fix: sync live attributes in CC2 client _handle_attributes"
+
+**Acceptance criteria:**
+- [ ] `_handle_attributes()` calls `self.printer.sync_from_attributes(mapped_attrs)` after setting `printer_data.attributes`, guarded by `if self.printer:`
+- [ ] No test regressions
+- [ ] Lint clean
+
+---
+
+### Task 3: Call sync from WebSocket attribute handler
+
+**Context:**
+The WebSocket client (for non-CC2 printers) receives attributes in `_attributes_handler()`. Same bug — it creates `PrinterAttributes` and stores in `printer_data.attributes` but never syncs to `self.printer`. Adding the same one-line call fixes this for WebSocket printers too.
+
+**Files:**
+- Modify: `custom_components/elegoo_printer/websocket/client.py`
+
+**What to implement:**
+- In `_attributes_handler(self, data: dict[str, Any])`, after the line `self.printer_data.attributes = printer_attributes`, add:
+  ```python
+  if self.printer:
+      self.printer.sync_from_attributes(printer_attributes)
+  ```
+- Guard with `if self.printer:` to avoid crash during disconnection race conditions
+- Do NOT modify any other code in this file
+- Do NOT add logging for the sync call (the method itself doesn't log, and callers shouldn't need to)
+
+**Steps:**
+- [ ] Add the `self.printer.sync_from_attributes(printer_attributes)` call in `websocket/client.py` `_attributes_handler()`
+- [ ] Run `make format` — confirm code is formatted
+- [ ] Run `make lint` — confirm no lint errors
+- [ ] Run `make test` — confirm no regressions
+- [ ] Commit with message: "fix: sync live attributes in WebSocket client _attributes_handler"
+
+**Acceptance criteria:**
+- [ ] `_attributes_handler()` calls `self.printer.sync_from_attributes(printer_attributes)` after setting `printer_data.attributes`, guarded by `if self.printer:`
+- [ ] No test regressions
+- [ ] Lint clean
+
+---
+
+### Task 4: Call sync from legacy MQTT attribute handler
+
+**Context:**
+The legacy `ElegooMqttClient` (for non-CC2 MQTT printers) has the identical bug in `mqtt/client.py:_attributes_handler()`. It creates `PrinterAttributes` and stores to `printer_data.attributes` but never syncs to `self.printer`. This task fixes the same gap for legacy MQTT printers.
+
+**Files:**
+- Modify: `custom_components/elegoo_printer/mqtt/client.py`
+
+**What to implement:**
+- In `_attributes_handler()`, after the line that sets `self.printer_data.attributes`, add:
+  ```python
+  if self.printer:
+      self.printer.sync_from_attributes(printer_attributes)
+  ```
+- Guard with `if self.printer:` to avoid crash during disconnection race conditions
+- Do NOT modify any other code in this file
+
+**Steps:**
+- [ ] Add the guarded `self.printer.sync_from_attributes(printer_attributes)` call in `mqtt/client.py` `_attributes_handler()`
+- [ ] Run `make format` — confirm code is formatted
+- [ ] Run `make lint` — confirm no lint errors
+- [ ] Run `make test` — confirm no regressions
+- [ ] Commit with message: "fix: sync live attributes in legacy MQTT client _attributes_handler"
+
+**Acceptance criteria:**
+- [ ] `_attributes_handler()` calls `sync_from_attributes` with `if self.printer:` guard
+- [ ] No test regressions
+- [ ] Lint clean
+
+---
+
+### Task 5: Verify end-to-end and close issue
+
+**Context:**
+After Tasks 1-4, the full data flow works at runtime: live attributes → `PrinterAttributes` → `Printer.sync_from_attributes()` → `self.printer.firmware` updated → firmware update check uses correct version. Note: `_update_config_entry_if_needed()` is only called at connect/reconnect time, so the config entry won't be persisted to disk until the next HA restart or reconnection. This is acceptable for MVP — runtime behavior is correct immediately.
+
+**Files:**
+- No new files
+
+**What to implement:**
+- Verify the full chain works by checking:
+  1. `api.py` `async_check_firmware_update()` uses `self.printer.firmware` — this is already correct, just verify
+  2. `api.py` `_update_config_entry_if_needed()` compares `printer.to_dict()` which includes firmware — verify this picks up changes at reconnect time
+  3. Run the full test suite one final time
+
+**Steps:**
+- [ ] Run `make test` — full test suite passes
+- [ ] Run `make format` — all code formatted
+- [ ] Run `make lint` — all lint clean
+- [ ] Review all four changed files for correctness
+- [ ] Commit with message: "chore: verify end-to-end attribute sync, close #377"
+- [ ] Close GitHub issue #377 with explanation of the fix
+
+**Acceptance criteria:**
+- [ ] Full test suite passes
+- [ ] All lint/format clean
+- [ ] Issue #377 closed with fix explanation

--- a/docs/plans/2025-06-25-sync-printer-attributes.md
+++ b/docs/plans/2025-06-25-sync-printer-attributes.md
@@ -8,7 +8,7 @@
 
 ---
 
-### Task 1: Add `Printer.sync_from_attributes()` method
+## Task 1: Add `Printer.sync_from_attributes()` method
 
 **Context:**
 `Printer.firmware` (and `model`, `name`, `brand`) is set once from the stored config entry via `Printer.from_dict()` and never refreshed. After the user updates printer firmware, the integration reads the stale value, causing incorrect firmware update checks and stale device info in Home Assistant. This task adds a method to sync live attributes with guards and dependent flag re-derivation.
@@ -64,7 +64,7 @@
 
 ---
 
-### Task 2: Call sync from CC2 attribute handler
+## Task 2: Call sync from CC2 attribute handler
 
 **Context:**
 The CC2 client receives attributes via MQTT in `_handle_attributes()`. Currently it maps the CC2 nested format to `PrinterAttributes` and stores in `printer_data.attributes`, but never syncs to `self.printer`. This means `self.printer.firmware` remains stale. Adding a one-line call to `sync_from_attributes()` fixes this.
@@ -96,7 +96,7 @@ The CC2 client receives attributes via MQTT in `_handle_attributes()`. Currently
 
 ---
 
-### Task 3: Call sync from WebSocket attribute handler
+## Task 3: Call sync from WebSocket attribute handler
 
 **Context:**
 The WebSocket client (for non-CC2 printers) receives attributes in `_attributes_handler()`. Same bug — it creates `PrinterAttributes` and stores in `printer_data.attributes` but never syncs to `self.printer`. Adding the same one-line call fixes this for WebSocket printers too.
@@ -128,7 +128,7 @@ The WebSocket client (for non-CC2 printers) receives attributes in `_attributes_
 
 ---
 
-### Task 4: Call sync from legacy MQTT attribute handler
+## Task 4: Call sync from legacy MQTT attribute handler
 
 **Context:**
 The legacy `ElegooMqttClient` (for non-CC2 MQTT printers) has the identical bug in `mqtt/client.py:_attributes_handler()`. It creates `PrinterAttributes` and stores to `printer_data.attributes` but never syncs to `self.printer`. This task fixes the same gap for legacy MQTT printers.
@@ -159,7 +159,7 @@ The legacy `ElegooMqttClient` (for non-CC2 MQTT printers) has the identical bug 
 
 ---
 
-### Task 5: Verify end-to-end and close issue
+## Task 5: Verify end-to-end and close issue
 
 **Context:**
 After Tasks 1-4, the full data flow works at runtime: live attributes → `PrinterAttributes` → `Printer.sync_from_attributes()` → `self.printer.firmware` updated → firmware update check uses correct version. Note: `_update_config_entry_if_needed()` is only called at connect/reconnect time, so the config entry won't be persisted to disk until the next HA restart or reconnection. This is acceptable for MVP — runtime behavior is correct immediately.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,23 @@
+# Plans
+
+Implementation plans for features and fixes.
+
+## Quick Stats
+
+- **Total Plans:** 1
+- **In Progress:** 1
+- **Completed:** 0
+
+## Active Plans
+
+| Plan | Status | Date |
+|------|--------|------|
+| [Sync Live Attributes to Printer Object](2025-06-25-sync-printer-attributes.md) | 🚧 IN PROGRESS | 2025-06-25 |
+
+## Completed Plans
+
+_(none)_
+
+## Superseded Plans
+
+_(none)_

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -5,18 +5,18 @@ Implementation plans for features and fixes.
 ## Quick Stats
 
 - **Total Plans:** 1
-- **In Progress:** 1
-- **Completed:** 0
+- **In Progress:** 0
+- **Completed:** 1
 
 ## Active Plans
 
-| Plan | Status | Date |
-|------|--------|------|
-| [Sync Live Attributes to Printer Object](2025-06-25-sync-printer-attributes.md) | 🚧 IN PROGRESS | 2025-06-25 |
+_(none)_
 
 ## Completed Plans
 
-_(none)_
+| Plan | Status | Date | PR |
+|------|--------|------|----|
+| [Sync Live Attributes to Printer Object](2025-06-25-sync-printer-attributes.md) | ✅ COMPLETED | 2025-06-25 | [#379](https://github.com/danielcherubini/elegoo-homeassistant/pull/379) |
 
 ## Superseded Plans
 

--- a/uv.lock
+++ b/uv.lock
@@ -734,7 +734,7 @@ wheels = [
 
 [[package]]
 name = "elegoo-printer"
-version = "2.7.5"
+version = "2.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomqtt" },


### PR DESCRIPTION
## Summary

Fixes [#377](https://github.com/danielcherubini/elegoo-homeassistant/issues/377) — firmware version not detected after user updates printer firmware.

### Root Cause
`Printer.firmware` (and `model`, `name`, `brand`) was set once from the stored config entry via `Printer.from_dict()` and never refreshed from live MQTT/WebSocket attributes. After the user updates printer firmware, the integration continued reading the stale value, causing incorrect firmware update checks and stale device info in Home Assistant.

### Solution
- Add `Printer.sync_from_attributes(PrinterAttributes) -> bool` that copies live values with guards against empty/unchanged data and re-derives dependent flags (`printer_type`, `open_centauri`, `has_vat_heater`)
- Call from all 3 attribute handlers: CC2, WebSocket, and legacy MQTT clients
- All callers guarded with `if self.printer:` to avoid crashes during disconnection

### Changes
- `sdcp/models/printer.py` — New `sync_from_attributes()` method + 8 unit tests
- `cc2/client.py` — Call sync in `_handle_attributes()`
- `websocket/client.py` — Call sync in `_attributes_handler()`
- `mqtt/client.py` — Call sync in `_attributes_handler()`

### Test plan
- [ ] All 267 tests pass ✅
- [ ] `make format` clean ✅
- [ ] `make lint` clean ✅
- [ ] Manually verify: update printer firmware, confirm integration picks up new version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added attribute synchronization to update printer firmware, model, name, and brand across CC2, MQTT, and WebSocket clients.

* **Tests**
  * Added comprehensive tests for synchronization: updates vs skips (empty/unchanged), full-field sync, and re-derivation of dependent flags.

* **Documentation**
  * Added a plan describing the synchronization approach, acceptance criteria, and test matrix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/danielcherubini/elegoo-homeassistant/pull/379?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->