### PR TITLE
Bound CC2 discovery in the config flow so non-CC2 printers don't time it out

### DIFF
--- a/custom_components/elegoo_printer/cc2/const.py
+++ b/custom_components/elegoo_printer/cc2/const.py
@@ -9,6 +9,10 @@ CC2_DISCOVERY_PORT = 52700
 CC2_DISCOVERY_MESSAGE = {"id": 0, "method": 7000}
 CC2_DISCOVERY_TIMEOUT = 10  # Increased for slower networks/printers
 CC2_DISCOVERY_RETRIES = 2  # Number of broadcast attempts
+# Bounded discovery for interactive use (the config flow). A printer that does not
+# speak CC2 never answers, so the default timeout x (retries + 1) would block the
+# config-flow step long enough for the frontend to abort with "Unknown error".
+CC2_CONFIG_FLOW_DISCOVERY_TIMEOUT = 3  # seconds, single attempt (retries=0)
 
 # MQTT settings (printer runs broker)
 CC2_MQTT_PORT = 1883

--- a/custom_components/elegoo_printer/cc2/discovery.py
+++ b/custom_components/elegoo_printer/cc2/discovery.py
@@ -156,6 +156,8 @@ class CC2Discovery:
     @staticmethod
     def discover(
         broadcast_address: str = DEFAULT_BROADCAST_ADDRESS,
+        timeout: float | None = None,
+        retries: int | None = None,
     ) -> list[CC2DiscoveredPrinter]:
         """
         Broadcast a UDP discovery message to locate CC2 printers.
@@ -166,6 +168,12 @@ class CC2Discovery:
         Arguments:
             broadcast_address: The network address to send the discovery message to.
                 Can be a broadcast address (255.255.255.255) or a specific IP.
+            timeout: Per-attempt socket timeout in seconds. Defaults to
+                ``CC2_DISCOVERY_TIMEOUT``. Callers that must not block (e.g. the
+                config flow) can pass a small value.
+            retries: Number of additional broadcast attempts. Defaults to
+                ``CC2_DISCOVERY_RETRIES`` for broadcast, else 0. Pass 0 to avoid
+                stacking multiple full-timeout waits.
 
         Returns:
             A list of discovered CC2 printers, or an empty list if none are found.
@@ -174,17 +182,22 @@ class CC2Discovery:
         discovered_printers: list[CC2DiscoveredPrinter] = []
         seen_serial_numbers: set[str] = set()
         is_broadcast = broadcast_address == DEFAULT_BROADCAST_ADDRESS
+        discovery_timeout = CC2_DISCOVERY_TIMEOUT if timeout is None else timeout
+        retries = (
+            (CC2_DISCOVERY_RETRIES if is_broadcast else 0)
+            if retries is None
+            else retries
+        )
 
         LOGGER.info(
             "CC2 discovery on port %s (address: %s, timeout: %ss, retries: %d)...",
             CC2_DISCOVERY_PORT,
             broadcast_address,
-            CC2_DISCOVERY_TIMEOUT,
-            CC2_DISCOVERY_RETRIES if is_broadcast else 0,
+            discovery_timeout,
+            retries,
         )
 
         msg = json.dumps(CC2_DISCOVERY_MESSAGE).encode("utf-8")
-        retries = CC2_DISCOVERY_RETRIES if is_broadcast else 0
 
         with socket.socket(
             socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP
@@ -192,7 +205,7 @@ class CC2Discovery:
             # Allow reuse of address/port for multiple discovery attempts
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-            sock.settimeout(CC2_DISCOVERY_TIMEOUT)
+            sock.settimeout(discovery_timeout)
 
             # Bind to the discovery port to receive responses on the same port
             # This can be more reliable than using ephemeral ports in some networks
@@ -250,7 +263,7 @@ class CC2Discovery:
                                     "CC2 discovery timeout after %ss"
                                     " (attempt %d, received %d responses)"
                                 ),
-                                CC2_DISCOVERY_TIMEOUT,
+                                discovery_timeout,
                                 attempt + 1,
                                 responses_this_attempt,
                             )
@@ -293,6 +306,8 @@ class CC2Discovery:
     @staticmethod
     def discover_as_printers(
         broadcast_address: str = DEFAULT_BROADCAST_ADDRESS,
+        timeout: float | None = None,
+        retries: int | None = None,
     ) -> list[Printer]:
         """
         Discover CC2 printers and return them as Printer objects.
@@ -302,10 +317,14 @@ class CC2Discovery:
 
         Arguments:
             broadcast_address: The network address to send the discovery message to.
+            timeout: Per-attempt socket timeout in seconds (see ``discover``).
+            retries: Number of additional broadcast attempts (see ``discover``).
 
         Returns:
             A list of Printer objects configured for CC2 protocol.
 
         """
-        cc2_printers = CC2Discovery.discover(broadcast_address)
+        cc2_printers = CC2Discovery.discover(
+            broadcast_address, timeout=timeout, retries=retries
+        )
         return [p.to_printer() for p in cc2_printers]

--- a/custom_components/elegoo_printer/config_flow.py
+++ b/custom_components/elegoo_printer/config_flow.py
@@ -7,6 +7,7 @@ MIT License
 
 from __future__ import annotations
 
+from functools import partial
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
@@ -18,6 +19,7 @@ from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from .cc2.const import CC2_CONFIG_FLOW_DISCOVERY_TIMEOUT
 from .cc2.discovery import CC2Discovery
 from .cc2.gcode_proxy import GCodeProxyClient
 from .const import (
@@ -412,9 +414,17 @@ class ElegooFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             elegoo_printer_client.discover_printer
         )
 
-        # Also discover CC2 printers
+        # Also discover CC2 printers. Bound this to a short, single-attempt
+        # timeout: a printer that doesn't speak CC2 never answers, so the default
+        # CC2_DISCOVERY_TIMEOUT x (CC2_DISCOVERY_RETRIES + 1) would block this
+        # config-flow step long enough for the frontend to abort with the generic
+        # "Config flow could not be loaded: Unknown error".
         cc2_discovered = await self.hass.async_add_executor_job(
-            CC2Discovery.discover_as_printers
+            partial(
+                CC2Discovery.discover_as_printers,
+                timeout=CC2_CONFIG_FLOW_DISCOVERY_TIMEOUT,
+                retries=0,
+            )
         )
         LOGGER.debug("Discovered %d CC2 printer(s)", len(cc2_discovered))
 


### PR DESCRIPTION
Fixes #383

### Problem
On a printer that doesn't speak the CC2 protocol (e.g. an original **Centauri Carbon**), the config flow fails with the generic **"Config flow could not be loaded: Unknown error"** — no form is ever shown.

Cause: in `async_step_user`, after SDCP discovery (which already finds the printer), the integration runs a **CC2 UDP broadcast discovery unconditionally**. The printer never answers, so it waits `CC2_DISCOVERY_TIMEOUT` (10 s) × (`CC2_DISCOVERY_RETRIES` + 1 = 3) ≈ **30 s**, which overruns the frontend's flow-load window. The real reason is only visible at debug level:
```
[elegoo_printer]      Discovered: Centauri Carbon (192.168.68.114)     # SDCP found it
[elegoo_printer.cc2]  CC2 discovery on port 52700 (timeout: 10s, retries: 2)...
[elegoo_printer.cc2]  Response from <HA host> is not a CC2 discovery response   # printer never answers → ~30s wait
```

### Fix
Make the CC2 discovery **bounded when called from the config flow**, without changing its behaviour anywhere else:
- `CC2Discovery.discover()` / `discover_as_printers()` gain optional `timeout` and `retries` params that **default to the existing constants** → zero behaviour change for current callers (coordinator, manual-IP path, etc.).
- The config-flow call now passes a **single 3 s attempt** (`CC2_CONFIG_FLOW_DISCOVERY_TIMEOUT = 3`, `retries=0`). CC2 printers that respond quickly are still auto-discovered; non-CC2 printers no longer block the flow, so it loads and the user reaches the (existing) printer-selection / manual-IP step.

### Notes / trade-off
- No regression for existing callers (params default to the constants).
- A CC2 printer on a *very* slow network might not answer within 3 s during **auto-discovery**; it can still be added via the **manual-IP** step (which uses targeted discovery). Happy to make the config-flow timeout configurable or tune the value if you'd prefer.
- `ruff check` passes on the changed files; change is +39/−8 across 3 files.

### Testing
Tested against a real **Centauri Carbon** on HA Core 2026.6.4: before the patch the flow died with "Unknown error"; after it, the flow loads to the printer-selection step in ~8 s, and the debug log shows the bounded discovery:
```
[cc2] Sent CC2 discovery message ... (attempt 1)
[cc2] CC2 discovery timeout after 3s (attempt 1, received 1 responses)
[elegoo_printer] Discovered 0 CC2 printer(s)     # falls through cleanly, flow continues
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device discovery during setup so the app no longer waits too long when a printer doesn’t respond.
  * Added a shorter, bounded discovery attempt for the initial setup flow, making it feel faster and more responsive.
  * Refined discovery behavior to support configurable timing and retry limits for better handling of slower or unresponsive devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->