### PR TITLE
Fix CC2 auth fallback loop aborting before trying all passwords

### DIFF
--- a/custom_components/elegoo_printer/cc2/client.py
+++ b/custom_components/elegoo_printer/cc2/client.py
@@ -308,9 +308,13 @@ class ElegooCC2Client:
                 len(passwords_to_try),
                 auth_desc,
             )
-            # Stop trying if this was an auth failure (wrong credentials)
-            if self._last_auth_failure:
+            # Stop trying only if a user-provided code failed auth — no
+            # point falling back to defaults when the explicit code is wrong.
+            # When cycling fallback passwords, keep going: the first may fail
+            # while a later one succeeds (e.g. empty→rejected, "123456"→ok).
+            if self._last_auth_failure and self.access_code is not None:
                 break
+            self._last_auth_failure = False
             await self.disconnect()
 
         # All attempts failed
@@ -319,7 +323,7 @@ class ElegooCC2Client:
             "Please verify the access code in printer settings: "
             "Settings → Network → Access Code",
             self.printer.name,
-            len(passwords_to_try),
+            attempt_num,
         )
         return False
 

--- a/custom_components/elegoo_printer/cc2/tests/test_auth_fallback.py
+++ b/custom_components/elegoo_printer/cc2/tests/test_auth_fallback.py
@@ -1,0 +1,125 @@
+"""Tests for CC2 auth fallback behavior during password cycling."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from custom_components.elegoo_printer.cc2.client import ElegooCC2Client
+from custom_components.elegoo_printer.sdcp.models.printer import Printer
+
+
+def _make_client(access_code: str | None = None) -> ElegooCC2Client:
+  return ElegooCC2Client(
+    printer_ip="192.168.1.100",
+    serial_number="TEST123",
+    access_code=access_code,
+  )
+
+
+def _make_printer() -> Printer:
+  p = Printer()
+  p.name = "TestPrinter"
+  p.ip_address = "192.168.1.100"
+  p.id = "TEST123"
+  return p
+
+
+def test_fallback_continues_after_auth_failure() -> None:  # noqa: D103
+  """Empty password rejected (rc=5) must NOT prevent trying default '123456'."""
+  client = _make_client(access_code=None)
+  printer = _make_printer()
+  call_count = 0
+
+  async def side_effect(password: str) -> bool:
+    nonlocal call_count
+    call_count += 1
+    if password == "":
+      client._last_auth_failure = True
+      return False
+    if password == "123456":
+      return True
+    return False
+
+  async def run() -> bool:
+    with (
+      patch.object(client, "_try_connect_with_password", side_effect=side_effect),
+      patch.object(client, "disconnect", new_callable=AsyncMock),
+    ):
+      return await client.connect_printer(printer)
+
+  result = asyncio.run(run())
+  assert result is True, "Should succeed on the '123456' fallback"
+  assert call_count == 2, "Should have tried both passwords"
+
+
+def test_user_provided_code_stops_on_auth_failure() -> None:  # noqa: D103
+  """When user explicitly provides an access code and it fails auth, stop immediately."""
+  client = _make_client(access_code="mycode")
+  printer = _make_printer()
+  call_count = 0
+
+  async def side_effect(password: str) -> bool:
+    nonlocal call_count
+    call_count += 1
+    client._last_auth_failure = True
+    return False
+
+  async def run() -> bool:
+    with (
+      patch.object(client, "_try_connect_with_password", side_effect=side_effect),
+      patch.object(client, "disconnect", new_callable=AsyncMock),
+    ):
+      return await client.connect_printer(printer)
+
+  result = asyncio.run(run())
+  assert result is False
+  assert call_count == 1, "Should stop after the user-provided code fails"
+
+
+def test_fallback_all_fail_reports_correct_attempt_count() -> None:  # noqa: D103
+  """Error log should report actual attempt count, not list length."""
+  client = _make_client(access_code=None)
+  printer = _make_printer()
+
+  async def side_effect(password: str) -> bool:
+    return False
+
+  async def run() -> tuple[bool, int]:
+    with (
+      patch.object(client, "_try_connect_with_password", side_effect=side_effect),
+      patch.object(client, "disconnect", new_callable=AsyncMock),
+      patch.object(client.logger, "error") as mock_log,
+    ):
+      result = await client.connect_printer(printer)
+      logged_count = mock_log.call_args[0][2]
+      return result, logged_count
+
+  result, logged_count = asyncio.run(run())
+  assert result is False
+  assert logged_count == 2, "Should report 2 actual attempts"
+
+
+def test_auth_failure_flag_reset_between_fallback_attempts() -> None:  # noqa: D103
+  """_last_auth_failure must be cleared between fallback attempts."""
+  client = _make_client(access_code=None)
+  printer = _make_printer()
+  flags_seen: list[bool] = []
+
+  async def side_effect(password: str) -> bool:
+    flags_seen.append(client._last_auth_failure)
+    if password == "":
+      client._last_auth_failure = True
+    return False
+
+  async def run() -> None:
+    with (
+      patch.object(client, "_try_connect_with_password", side_effect=side_effect),
+      patch.object(client, "disconnect", new_callable=AsyncMock),
+    ):
+      await client.connect_printer(printer)
+
+  asyncio.run(run())
+  assert flags_seen == [False, False], (
+    "Flag should be False at the start of each attempt"
+  )

--- a/custom_components/elegoo_printer/cc2/tests/test_auth_fallback.py
+++ b/custom_components/elegoo_printer/cc2/tests/test_auth_fallback.py
@@ -6,120 +6,121 @@ import asyncio
 from unittest.mock import AsyncMock, patch
 
 from custom_components.elegoo_printer.cc2.client import ElegooCC2Client
+from custom_components.elegoo_printer.cc2.const import CC2_MQTT_DEFAULT_PASSWORD
 from custom_components.elegoo_printer.sdcp.models.printer import Printer
+
+_EXPECTED_FALLBACK_COUNT = 2
 
 
 def _make_client(access_code: str | None = None) -> ElegooCC2Client:
-  return ElegooCC2Client(
-    printer_ip="192.168.1.100",
-    serial_number="TEST123",
-    access_code=access_code,
-  )
+    return ElegooCC2Client(
+        printer_ip="192.168.1.100",
+        serial_number="TEST123",
+        access_code=access_code,
+    )
 
 
 def _make_printer() -> Printer:
-  p = Printer()
-  p.name = "TestPrinter"
-  p.ip_address = "192.168.1.100"
-  p.id = "TEST123"
-  return p
+    p = Printer()
+    p.name = "TestPrinter"
+    p.ip_address = "192.168.1.100"
+    p.id = "TEST123"
+    return p
 
 
-def test_fallback_continues_after_auth_failure() -> None:  # noqa: D103
-  """Empty password rejected (rc=5) must NOT prevent trying default '123456'."""
-  client = _make_client(access_code=None)
-  printer = _make_printer()
-  call_count = 0
+def test_fallback_continues_after_auth_failure() -> None:
+    """Empty password rejected must NOT prevent trying default '123456'."""
+    client = _make_client(access_code=None)
+    printer = _make_printer()
+    call_count = 0
 
-  async def side_effect(password: str) -> bool:
-    nonlocal call_count
-    call_count += 1
-    if password == "":
-      client._last_auth_failure = True
-      return False
-    if password == "123456":
-      return True
-    return False
+    async def side_effect(password: str) -> bool:
+        nonlocal call_count
+        call_count += 1
+        if password == "":
+            client._last_auth_failure = True
+            return False
+        return password == CC2_MQTT_DEFAULT_PASSWORD
 
-  async def run() -> bool:
-    with (
-      patch.object(client, "_try_connect_with_password", side_effect=side_effect),
-      patch.object(client, "disconnect", new_callable=AsyncMock),
-    ):
-      return await client.connect_printer(printer)
+    async def run() -> bool:
+        with (
+            patch.object(client, "_try_connect_with_password", side_effect=side_effect),
+            patch.object(client, "disconnect", new_callable=AsyncMock),
+        ):
+            return await client.connect_printer(printer)
 
-  result = asyncio.run(run())
-  assert result is True, "Should succeed on the '123456' fallback"
-  assert call_count == 2, "Should have tried both passwords"
+    result = asyncio.run(run())
+    assert result is True, "Should succeed on the '123456' fallback"
+    assert call_count == _EXPECTED_FALLBACK_COUNT
 
 
-def test_user_provided_code_stops_on_auth_failure() -> None:  # noqa: D103
-  """When user explicitly provides an access code and it fails auth, stop immediately."""
-  client = _make_client(access_code="mycode")
-  printer = _make_printer()
-  call_count = 0
+def test_user_code_stops_on_auth_failure() -> None:
+    """User-provided access code that fails auth should stop immediately."""
+    client = _make_client(access_code="mycode")
+    printer = _make_printer()
+    call_count = 0
 
-  async def side_effect(password: str) -> bool:
-    nonlocal call_count
-    call_count += 1
-    client._last_auth_failure = True
-    return False
+    async def side_effect(_password: str) -> bool:
+        nonlocal call_count
+        call_count += 1
+        client._last_auth_failure = True
+        return False
 
-  async def run() -> bool:
-    with (
-      patch.object(client, "_try_connect_with_password", side_effect=side_effect),
-      patch.object(client, "disconnect", new_callable=AsyncMock),
-    ):
-      return await client.connect_printer(printer)
+    async def run() -> bool:
+        with (
+            patch.object(client, "_try_connect_with_password", side_effect=side_effect),
+            patch.object(client, "disconnect", new_callable=AsyncMock),
+        ):
+            return await client.connect_printer(printer)
 
-  result = asyncio.run(run())
-  assert result is False
-  assert call_count == 1, "Should stop after the user-provided code fails"
-
-
-def test_fallback_all_fail_reports_correct_attempt_count() -> None:  # noqa: D103
-  """Error log should report actual attempt count, not list length."""
-  client = _make_client(access_code=None)
-  printer = _make_printer()
-
-  async def side_effect(password: str) -> bool:
-    return False
-
-  async def run() -> tuple[bool, int]:
-    with (
-      patch.object(client, "_try_connect_with_password", side_effect=side_effect),
-      patch.object(client, "disconnect", new_callable=AsyncMock),
-      patch.object(client.logger, "error") as mock_log,
-    ):
-      result = await client.connect_printer(printer)
-      logged_count = mock_log.call_args[0][2]
-      return result, logged_count
-
-  result, logged_count = asyncio.run(run())
-  assert result is False
-  assert logged_count == 2, "Should report 2 actual attempts"
+    result = asyncio.run(run())
+    assert result is False
+    assert call_count == 1
 
 
-def test_auth_failure_flag_reset_between_fallback_attempts() -> None:  # noqa: D103
-  """_last_auth_failure must be cleared between fallback attempts."""
-  client = _make_client(access_code=None)
-  printer = _make_printer()
-  flags_seen: list[bool] = []
+def test_all_fail_reports_correct_attempt_count() -> None:
+    """Error log should report actual attempt count, not list length."""
+    client = _make_client(access_code=None)
+    printer = _make_printer()
 
-  async def side_effect(password: str) -> bool:
-    flags_seen.append(client._last_auth_failure)
-    if password == "":
-      client._last_auth_failure = True
-    return False
+    async def side_effect(_password: str) -> bool:
+        return False
 
-  async def run() -> None:
-    with (
-      patch.object(client, "_try_connect_with_password", side_effect=side_effect),
-      patch.object(client, "disconnect", new_callable=AsyncMock),
-    ):
-      await client.connect_printer(printer)
+    async def run() -> tuple[bool, int]:
+        with (
+            patch.object(client, "_try_connect_with_password", side_effect=side_effect),
+            patch.object(client, "disconnect", new_callable=AsyncMock),
+            patch.object(client.logger, "error") as mock_log,
+        ):
+            result = await client.connect_printer(printer)
+            logged_count = mock_log.call_args[0][2]
+            return result, logged_count
 
-  asyncio.run(run())
-  assert flags_seen == [False, False], (
-    "Flag should be False at the start of each attempt"
-  )
+    result, logged_count = asyncio.run(run())
+    assert result is False
+    assert logged_count == _EXPECTED_FALLBACK_COUNT
+
+
+def test_auth_failure_flag_reset_between_attempts() -> None:
+    """_last_auth_failure must be cleared between fallback attempts."""
+    client = _make_client(access_code=None)
+    printer = _make_printer()
+    flags_seen: list[bool] = []
+
+    async def side_effect(password: str) -> bool:
+        flags_seen.append(client._last_auth_failure)
+        if password == "":
+            client._last_auth_failure = True
+        return False
+
+    async def run() -> None:
+        with (
+            patch.object(client, "_try_connect_with_password", side_effect=side_effect),
+            patch.object(client, "disconnect", new_callable=AsyncMock),
+        ):
+            await client.connect_printer(printer)
+
+    asyncio.run(run())
+    assert flags_seen == [False, False], (
+        "Flag should be False at the start of each attempt"
+    )


### PR DESCRIPTION
## Summary

v2.10.0's auth failure detection (#385) unconditionally breaks the password loop on the first MQTT CONNACK rejection. This prevents CC2 printers that reject empty passwords (rc=5 "Not authorized") from ever reaching the default `"123456"` password — which may be the one that actually works.

- **Only break on auth failure when the user explicitly provided an access code** (`self.access_code is not None`). When cycling fallback passwords (no access code), keep going — the next password may succeed.
- **Reset `_last_auth_failure` between fallback attempts** so the flag from a rejected empty password doesn't pass into the next iteration.
- **Fix misleading error log** — was logging `len(passwords_to_try)` (total list size) instead of `attempt_num` (actual attempts made).

## Root Cause

`connect_printer()` tries passwords in order: `["", "123456"]` when no access code is provided. The auth detection added in #385 correctly identifies CONNACK rc=4/5 as auth failures, but the break was unconditional:

```python
# Before (v2.10.0) — breaks after first rejection, never tries "123456"
if self._last_auth_failure:
    break
```

```python
# After — only breaks when a user-provided code fails
if self._last_auth_failure and self.access_code is not None:
    break
self._last_auth_failure = False
```

## Reproduction

Centauri Carbon 2 in LAN-only mode (`token_status=0`, no access code configured on the printer). Direct MQTT probing confirmed:

| Password | Result |
|----------|--------|
| `""` (empty) | CONNACK rc=135 "Not authorized" ❌ |
| `"123456"` | CONNACK rc=0, registered, status=IDLE ✅ |

Pre-v2.10.0 this worked because auth failures were caught generically and the loop continued. The new detection turned a benign first-attempt failure into a hard stop.

## Test plan

- [x] 4 new unit tests in `test_auth_fallback.py` covering: fallback continues past auth failure, user-provided code still stops early, correct attempt count in error log, flag reset between attempts
- [x] All 69 CC2 tests pass (65 existing + 4 new)
- [x] Live-tested against real CC2 hardware — empty password rejected, loop continues, "123456" connects and registers successfully, printer reports IDLE

🤖 Generated with [Claude Code](https://claude.com/claude-code)