### PR TITLE
Fix MQTT/legacy transport localhost bug + optional external broker support

### DIFF
--- a/custom_components/elegoo_printer/api.py
+++ b/custom_components/elegoo_printer/api.py
@@ -232,19 +232,20 @@ class ElegooPrinterApiClient:
         elif printer.transport_type == TransportType.MQTT:
             logger.info("Using MQTT transport for printer %s", printer.name)
 
-            # The printer always needs a LAN-reachable address for the M66666
-            # redirect command -- "localhost" on its own firmware means its own
-            # loopback, not Home Assistant, regardless of which broker is used.
             external_ip = getattr(printer, "external_ip", None)
-            advertise_host = PrinterData.get_local_ip(printer.ip_address, external_ip)
-
             mqtt_external_host = getattr(printer, "mqtt_external_host", None)
+
             if mqtt_external_host:
                 # Use an external broker (e.g. Mosquitto) instead of starting
                 # the embedded one.
                 mqtt_host = mqtt_external_host
                 mqtt_external_port = getattr(printer, "mqtt_external_port", None)
                 mqtt_port = int(mqtt_external_port) if mqtt_external_port else MQTT_PORT
+                # The printer should dial the external broker's own address by
+                # default; external_ip remains an explicit override for setups
+                # where mqtt_external_host (e.g. a Docker-internal name) isn't
+                # what the printer can reach on the LAN.
+                advertise_host = external_ip or mqtt_external_host
                 logger.info(
                     "Using external MQTT broker %s:%s for printer %s",
                     mqtt_host,
@@ -260,6 +261,12 @@ class ElegooPrinterApiClient:
                 mqtt_host = "localhost"
                 mqtt_port = (
                     self.mqtt_broker.port if self.mqtt_broker else MQTT_BROKER_PORT
+                )
+                # The printer always needs a LAN-reachable address for the M66666
+                # redirect command -- "localhost" on its own firmware means its own
+                # loopback, not Home Assistant.
+                advertise_host = PrinterData.get_local_ip(
+                    printer.ip_address, external_ip
                 )
 
             self.client = ElegooMqttClient(

--- a/custom_components/elegoo_printer/api.py
+++ b/custom_components/elegoo_printer/api.py
@@ -242,9 +242,16 @@ class ElegooPrinterApiClient:
             mqtt_host = "localhost"
             mqtt_port = self.mqtt_broker.port if self.mqtt_broker else MQTT_BROKER_PORT
 
+            # The printer always needs a LAN-reachable address for the M66666
+            # redirect command -- "localhost" on its own firmware means its own
+            # loopback, not Home Assistant.
+            external_ip = getattr(printer, "external_ip", None)
+            advertise_host = PrinterData.get_local_ip(printer.ip_address, external_ip)
+
             self.client = ElegooMqttClient(
                 mqtt_host=mqtt_host,
                 mqtt_port=mqtt_port,
+                advertise_host=advertise_host,
                 logger=logger,
                 printer=printer,
             )

--- a/custom_components/elegoo_printer/api.py
+++ b/custom_components/elegoo_printer/api.py
@@ -28,7 +28,7 @@ from .const import (
     LOGGER,
 )
 from .mqtt.client import ElegooMqttClient
-from .mqtt.const import MQTT_BROKER_PORT
+from .mqtt.const import MQTT_BROKER_PORT, MQTT_PORT
 from .mqtt.server import ElegooMQTTBroker
 from .sdcp.exceptions import ElegooPrinterConnectionError
 from .sdcp.models.elegoo_image import ElegooImage
@@ -232,21 +232,35 @@ class ElegooPrinterApiClient:
         elif printer.transport_type == TransportType.MQTT:
             logger.info("Using MQTT transport for printer %s", printer.name)
 
-            # Start embedded MQTT broker (always enabled for MQTT printers)
-            printer = await self._setup_mqtt_broker_if_enabled(printer)
-            if printer is None:
-                # Broker failed to start
-                return None
-
-            # Always use embedded broker on localhost
-            mqtt_host = "localhost"
-            mqtt_port = self.mqtt_broker.port if self.mqtt_broker else MQTT_BROKER_PORT
-
             # The printer always needs a LAN-reachable address for the M66666
             # redirect command -- "localhost" on its own firmware means its own
-            # loopback, not Home Assistant.
+            # loopback, not Home Assistant, regardless of which broker is used.
             external_ip = getattr(printer, "external_ip", None)
             advertise_host = PrinterData.get_local_ip(printer.ip_address, external_ip)
+
+            mqtt_external_host = getattr(printer, "mqtt_external_host", None)
+            if mqtt_external_host:
+                # Use an external broker (e.g. Mosquitto) instead of starting
+                # the embedded one.
+                mqtt_host = mqtt_external_host
+                mqtt_external_port = getattr(printer, "mqtt_external_port", None)
+                mqtt_port = int(mqtt_external_port) if mqtt_external_port else MQTT_PORT
+                logger.info(
+                    "Using external MQTT broker %s:%s for printer %s",
+                    mqtt_host,
+                    mqtt_port,
+                    printer.name,
+                )
+            else:
+                # Start embedded MQTT broker (always enabled for MQTT printers)
+                printer = await self._setup_mqtt_broker_if_enabled(printer)
+                if printer is None:
+                    # Broker failed to start
+                    return None
+                mqtt_host = "localhost"
+                mqtt_port = (
+                    self.mqtt_broker.port if self.mqtt_broker else MQTT_BROKER_PORT
+                )
 
             self.client = ElegooMqttClient(
                 mqtt_host=mqtt_host,

--- a/custom_components/elegoo_printer/config_flow.py
+++ b/custom_components/elegoo_printer/config_flow.py
@@ -27,6 +27,8 @@ from .const import (
     CONF_CC2_ACCESS_CODE,
     CONF_EXTERNAL_IP,
     CONF_GCODE_PROXY_URL,
+    CONF_MQTT_EXTERNAL_HOST,
+    CONF_MQTT_EXTERNAL_PORT,
     CONF_PROXY_ENABLED,
     DOMAIN,
     LOGGER,
@@ -1174,6 +1176,8 @@ class ElegooOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             printer.ip_address = user_input.get(CONF_IP_ADDRESS, printer.ip_address)
             printer.external_ip = user_input.get(CONF_EXTERNAL_IP)
+            printer.mqtt_external_host = user_input.get(CONF_MQTT_EXTERNAL_HOST)
+            printer.mqtt_external_port = user_input.get(CONF_MQTT_EXTERNAL_PORT)
             return self.async_create_entry(
                 title=printer.name,
                 data=printer.to_dict(),
@@ -1184,6 +1188,12 @@ class ElegooOptionsFlowHandler(config_entries.OptionsFlow):
                 selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT),
             ),
             vol.Optional(CONF_EXTERNAL_IP): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT),
+            ),
+            vol.Optional(CONF_MQTT_EXTERNAL_HOST): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT),
+            ),
+            vol.Optional(CONF_MQTT_EXTERNAL_PORT): selector.TextSelector(
                 selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT),
             ),
         }

--- a/custom_components/elegoo_printer/config_flow.py
+++ b/custom_components/elegoo_printer/config_flow.py
@@ -1173,16 +1173,6 @@ class ElegooOptionsFlowHandler(config_entries.OptionsFlow):
         }
         printer = Printer.from_dict(current_settings)
 
-        if user_input is not None:
-            printer.ip_address = user_input.get(CONF_IP_ADDRESS, printer.ip_address)
-            printer.external_ip = user_input.get(CONF_EXTERNAL_IP)
-            printer.mqtt_external_host = user_input.get(CONF_MQTT_EXTERNAL_HOST)
-            printer.mqtt_external_port = user_input.get(CONF_MQTT_EXTERNAL_PORT)
-            return self.async_create_entry(
-                title=printer.name,
-                data=printer.to_dict(),
-            )
-
         data_schema = {
             vol.Required(CONF_IP_ADDRESS): selector.TextSelector(
                 selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT),
@@ -1197,6 +1187,34 @@ class ElegooOptionsFlowHandler(config_entries.OptionsFlow):
                 selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT),
             ),
         }
+
+        if user_input is not None:
+            printer.ip_address = user_input.get(CONF_IP_ADDRESS, printer.ip_address)
+            printer.external_ip = user_input.get(CONF_EXTERNAL_IP)
+            printer.mqtt_external_host = user_input.get(CONF_MQTT_EXTERNAL_HOST)
+
+            port_raw = (user_input.get(CONF_MQTT_EXTERNAL_PORT) or "").strip()
+            if port_raw:
+                if not port_raw.isdigit() or not (
+                    1 <= int(port_raw) <= 65535  # noqa: PLR2004
+                ):
+                    _errors[CONF_MQTT_EXTERNAL_PORT] = "mqtt_external_port_invalid"
+                    return self.async_show_form(
+                        step_id="mqtt_options",
+                        data_schema=self.add_suggested_values_to_schema(
+                            vol.Schema(data_schema),
+                            suggested_values=user_input,
+                        ),
+                        errors=_errors,
+                    )
+                printer.mqtt_external_port = port_raw
+            else:
+                printer.mqtt_external_port = None
+
+            return self.async_create_entry(
+                title=printer.name,
+                data=printer.to_dict(),
+            )
 
         return self.async_show_form(
             step_id="mqtt_options",

--- a/custom_components/elegoo_printer/config_flow.py
+++ b/custom_components/elegoo_printer/config_flow.py
@@ -1173,6 +1173,7 @@ class ElegooOptionsFlowHandler(config_entries.OptionsFlow):
 
         if user_input is not None:
             printer.ip_address = user_input.get(CONF_IP_ADDRESS, printer.ip_address)
+            printer.external_ip = user_input.get(CONF_EXTERNAL_IP)
             return self.async_create_entry(
                 title=printer.name,
                 data=printer.to_dict(),
@@ -1180,6 +1181,9 @@ class ElegooOptionsFlowHandler(config_entries.OptionsFlow):
 
         data_schema = {
             vol.Required(CONF_IP_ADDRESS): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT),
+            ),
+            vol.Optional(CONF_EXTERNAL_IP): selector.TextSelector(
                 selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT),
             ),
         }

--- a/custom_components/elegoo_printer/const.py
+++ b/custom_components/elegoo_printer/const.py
@@ -23,7 +23,7 @@ CONF_PROXY_ENABLED = "proxy_enabled"
 CONF_PROXY_WEBSOCKET_PORT = "proxy_websocket_port"
 CONF_PROXY_VIDEO_PORT = "proxy_video_port"
 
-# MQTT settings (always uses embedded broker)
+# MQTT settings
 CONF_MQTT_BROKER_ENABLED = "mqtt_broker_enabled"
 CONF_MQTT_EXTERNAL_HOST = "mqtt_external_host"
 CONF_MQTT_EXTERNAL_PORT = "mqtt_external_port"

--- a/custom_components/elegoo_printer/const.py
+++ b/custom_components/elegoo_printer/const.py
@@ -25,6 +25,8 @@ CONF_PROXY_VIDEO_PORT = "proxy_video_port"
 
 # MQTT settings (always uses embedded broker)
 CONF_MQTT_BROKER_ENABLED = "mqtt_broker_enabled"
+CONF_MQTT_EXTERNAL_HOST = "mqtt_external_host"
+CONF_MQTT_EXTERNAL_PORT = "mqtt_external_port"
 
 # CC2-specific settings
 CONF_CC2_ACCESS_CODE = "cc2_access_code"

--- a/custom_components/elegoo_printer/mqtt/client.py
+++ b/custom_components/elegoo_printer/mqtt/client.py
@@ -86,6 +86,7 @@ class ElegooMqttClient:
         self,
         mqtt_host: str = "localhost",
         mqtt_port: int = MQTT_PORT,
+        advertise_host: str | None = None,
         logger: Any = LOGGER,
         printer: Printer | None = None,
     ) -> None:
@@ -97,12 +98,17 @@ class ElegooMqttClient:
         Arguments:
             mqtt_host: The MQTT broker hostname.
             mqtt_port: The MQTT broker port.
+            advertise_host: The host to tell the printer to connect to via the
+                M66666 command, if different from mqtt_host (e.g. when this
+                client reaches the broker over a different path than the
+                printer does).
             logger: The logger to use.
             printer: Optional Printer object with existing configuration.
 
         """
         self.mqtt_host = mqtt_host
         self.mqtt_port = mqtt_port
+        self.advertise_host = advertise_host or mqtt_host
         self.mqtt_client: aiomqtt.Client | None = None
         self.printer: Printer = printer or Printer()
         self.printer_data = PrinterData(printer=self.printer)
@@ -174,7 +180,7 @@ class ElegooMqttClient:
             # Construct M66666 command with MQTT broker host and port
             # Format: M66666 <host> <port>
             # No authentication - embedded broker doesn't require credentials
-            message_parts = ["M66666", str(self.mqtt_host), str(self.mqtt_port)]
+            message_parts = ["M66666", str(self.advertise_host), str(self.mqtt_port)]
             message = " ".join(message_parts).encode()
 
             # Send to printer's discovery port
@@ -184,7 +190,7 @@ class ElegooMqttClient:
             self.logger.info(
                 "Sent M66666 command to printer %s to connect to MQTT broker %s:%s",
                 printer_ip,
-                self.mqtt_host,
+                self.advertise_host,
                 self.mqtt_port,
             )
         except OSError:

--- a/custom_components/elegoo_printer/sdcp/models/printer.py
+++ b/custom_components/elegoo_printer/sdcp/models/printer.py
@@ -16,6 +16,8 @@ from custom_components.elegoo_printer.const import (
     CONF_CC2_TOKEN_STATUS,
     CONF_EXTERNAL_IP,
     CONF_MQTT_BROKER_ENABLED,
+    CONF_MQTT_EXTERNAL_HOST,
+    CONF_MQTT_EXTERNAL_PORT,
     CONF_PROXY_ENABLED,
     DEFAULT_FALLBACK_IP,
     WEBSOCKET_PORT,
@@ -205,6 +207,8 @@ class Printer:
         self.camera_enabled = config.get(CONF_CAMERA_ENABLED, False)
         self.mqtt_broker_enabled = config.get(CONF_MQTT_BROKER_ENABLED, False)
         self.external_ip = config.get(CONF_EXTERNAL_IP)
+        self.mqtt_external_host = config.get(CONF_MQTT_EXTERNAL_HOST)
+        self.mqtt_external_port = config.get(CONF_MQTT_EXTERNAL_PORT)
         self.proxy_websocket_port = None
         self.proxy_video_port = None
         # CC2-specific settings
@@ -286,6 +290,8 @@ class Printer:
             "is_proxy": self.is_proxy,
             "mqtt_broker_enabled": self.mqtt_broker_enabled,
             "external_ip": self.external_ip,
+            "mqtt_external_host": self.mqtt_external_host,
+            "mqtt_external_port": self.mqtt_external_port,
             "open_centauri": self.open_centauri,
             "has_vat_heater": self.has_vat_heater,
             "cc2_access_code": self.cc2_access_code,
@@ -410,6 +416,12 @@ class Printer:
         printer.proxy_video_port = attrs.get("proxy_video_port")
         printer.is_proxy = attrs.get("Proxy", attrs.get("is_proxy", False))
         printer.external_ip = attrs.get(CONF_EXTERNAL_IP, attrs.get("external_ip"))
+        printer.mqtt_external_host = attrs.get(
+            CONF_MQTT_EXTERNAL_HOST, attrs.get("mqtt_external_host")
+        )
+        printer.mqtt_external_port = attrs.get(
+            CONF_MQTT_EXTERNAL_PORT, attrs.get("mqtt_external_port")
+        )
 
         # Calculate open_centauri based on model and firmware
         printer.open_centauri = Printer._is_open_centauri(

--- a/custom_components/elegoo_printer/tests/test_config_flow_mqtt_options.py
+++ b/custom_components/elegoo_printer/tests/test_config_flow_mqtt_options.py
@@ -1,0 +1,93 @@
+"""Tests for MQTT options flow (external port validation)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+from homeassistant.const import CONF_IP_ADDRESS
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.elegoo_printer.config_flow import ElegooOptionsFlowHandler
+from custom_components.elegoo_printer.const import CONF_MQTT_EXTERNAL_PORT
+
+_DOC_IP = "192.0.2.1"
+
+MQTT_ENTRY_DATA = {
+    "name": "MQTT Unit Test",
+    "ip_address": _DOC_IP,
+    "transport_type": "mqtt",
+    "protocol_version": "V1",
+    "protocol": "V1.0.0",
+    "id": "test-board-id",
+    "model": "ELEGOO Test Printer",
+}
+
+
+def _make_options_flow() -> ElegooOptionsFlowHandler:
+    entry = MagicMock()
+    entry.data = dict(MQTT_ENTRY_DATA)
+    entry.options = {}
+    flow = ElegooOptionsFlowHandler(entry)
+    flow.hass = MagicMock()
+    flow.flow_id = "options-test-flow"
+    flow.handler = "elegoo_printer"
+    return flow
+
+
+class TestAsyncStepMqttOptionsPortValidation:
+    """``ElegooOptionsFlowHandler.async_step_mqtt_options`` port validation."""
+
+    def test_non_numeric_port_returns_form_error(self) -> None:
+        """A non-numeric port surfaces ``mqtt_external_port_invalid``."""
+
+        async def _run() -> None:
+            flow = _make_options_flow()
+            result = await flow.async_step_mqtt_options(
+                user_input={
+                    CONF_IP_ADDRESS: _DOC_IP,
+                    CONF_MQTT_EXTERNAL_PORT: "abc",
+                },
+            )
+            assert result["type"] == FlowResultType.FORM
+            assert result["step_id"] == "mqtt_options"
+            assert (
+                result["errors"][CONF_MQTT_EXTERNAL_PORT]
+                == "mqtt_external_port_invalid"
+            )
+
+        asyncio.run(_run())
+
+    def test_out_of_range_port_returns_form_error(self) -> None:
+        """A port outside 1-65535 surfaces the same error."""
+
+        async def _run() -> None:
+            flow = _make_options_flow()
+            result = await flow.async_step_mqtt_options(
+                user_input={
+                    CONF_IP_ADDRESS: _DOC_IP,
+                    CONF_MQTT_EXTERNAL_PORT: "70000",
+                },
+            )
+            assert result["type"] == FlowResultType.FORM
+            assert (
+                result["errors"][CONF_MQTT_EXTERNAL_PORT]
+                == "mqtt_external_port_invalid"
+            )
+
+        asyncio.run(_run())
+
+    def test_valid_port_creates_entry(self) -> None:
+        """A valid numeric port saves without error."""
+
+        async def _run() -> None:
+            flow = _make_options_flow()
+            result = await flow.async_step_mqtt_options(
+                user_input={
+                    CONF_IP_ADDRESS: _DOC_IP,
+                    CONF_MQTT_EXTERNAL_PORT: "1883",
+                },
+            )
+            assert result["type"] == FlowResultType.CREATE_ENTRY
+
+        asyncio.run(_run())

--- a/custom_components/elegoo_printer/translations/en.json
+++ b/custom_components/elegoo_printer/translations/en.json
@@ -29,7 +29,15 @@
         "title": "MQTT Printer Options",
         "description": "Configure your MQTT printer settings.",
         "data": {
-          "ip_address": "Printer IP Address"
+          "ip_address": "Printer IP Address",
+          "external_ip": "External Address (optional, for advanced network setups)",
+          "mqtt_external_host": "External MQTT Broker Host (optional)",
+          "mqtt_external_port": "External MQTT Broker Port (optional)"
+        },
+        "data_description": {
+          "external_ip": "Override auto-detected address with an IP address or hostname. Leave blank for automatic detection. Use for Kubernetes/Docker setups or when behind a reverse proxy. Ports 3030 and 3031 will be appended automatically.",
+          "mqtt_external_host": "Point at an existing MQTT broker (e.g. Mosquitto) instead of starting the embedded one. Leave blank to use the built-in broker.",
+          "mqtt_external_port": "Port for the external MQTT broker specified above. Defaults to 1883 if left blank."
         }
       },
       "websocket_options": {
@@ -115,7 +123,8 @@
       "cc2_access_code_required": "This printer requires an access code for authentication.",
       "cc2_authentication_failed": "Failed to authenticate. Make sure LAN Only Mode is enabled on your printer (Settings → Network → LAN Only Mode), then verify the access code in Settings → Network → Access Code.",
       "gcode_proxy_unreachable": "Cannot reach the GCode proxy server. Verify the address or URL and that the proxy is running.",
-      "gcode_proxy_invalid": "Invalid GCode proxy address. Use a host or host:port, or an http(s) URL without duplicate schemes."
+      "gcode_proxy_invalid": "Invalid GCode proxy address. Use a host or host:port, or an http(s) URL without duplicate schemes.",
+      "mqtt_external_port_invalid": "Invalid port. Enter a whole number between 1 and 65535."
     },
     "abort": {
       "already_configured": "This entry is already configured."


### PR DESCRIPTION
This PR has two related changes to the MQTT/legacy transport path (`ProtocolVersion.V1`, e.g. Mars 4 Ultra), as two separate commits:

1. **Fix**: the M66666 redirect command sent to the printer hardcodes the broker host as `"localhost"`. That resolves against the printer's own loopback, not Home Assistant, which prevents the printer from reaching the broker. Setup times out and the integration retries indefinitely (`MQTT Broker stop timed out, forcing shutdown` / `MQTT listener exception` in a repeating loop). This PR's first commit:
-  adds an `advertise_host` parameter to `ElegooMqttClient`, separate from `mqtt_host`, used only in the M66666 payload
- computes it via the existing `PrinterData.get_local_ip()` helper; `config_flow.py` exposes the same optional External IP field on the MQTT options step that the WebSocket options step already has.

2. **Feature**: adds two optional config fields, `mqtt_external_host` and `mqtt_external_port`, so the MQTT transport can point at an existing broker instead of always starting the embedded one. Useful for anyone who'd prefer to use an existing broker over the embedded one. 
 
Both changes are verified end-to-end against a physical Mars 4 Ultra (firmware V1.1.4, protocol V1.0.0) running behind a Mosquitto broker with a dedicated anonymous+ACL-scoped listener. I'd love to hear if either/both of these changes are welcome, and am happy to make other changes!

## Test plan

- [x] `ruff check` / `ruff format --check` pass on all changed files
- [x] Full `pytest` suite passes (108 passed)
- [x] Manually verified against a physical Mars 4 Ultra: previously stuck in the setup retry loop, now connects and reports live sensor state (layer count, percent complete, status, UV LED temp) through an external Mosquitto broker