### PR TITLE
Fix hostname matching during WebSocket discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- WebSocket discovery now recognizes hostnames by their resolved IPv4 address, and options updates validate the newly submitted address.
+
 ### Breaking Changes
 
 - The unique ID format for entities has changed to include the machine ID. This may cause Home Assistant to create new entities. The integration will attempt to migrate existing entities to the new format, but this may not be successful in all cases. If you experience issues, you may need to remove and re-add the integration.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The recommended way to install this integration is through the [Home Assistant C
 1. Go to **Settings** > **Devices & Services**.
 2. Click **"Add Integration"** and search for **"Elegoo Printers"**.
 3. The integration will attempt to **auto-discover** printers on your network.
-4. If no printer is found, select **"Configure manually"** and enter your printer's IP address. 
+4. If no printer is found, select **"Configure manually"** and enter your printer's IP address or hostname.
 
 **Note:** If **auto-discovery** didn't work, you may need some [advanced network setup](https://github.com/danielcherubini/elegoo-homeassistant/wiki/Connecting-Elegoo-Printers-to-Home-Assistant-Across-Different-Networks).
 

--- a/custom_components/elegoo_printer/api.py
+++ b/custom_components/elegoo_printer/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import re
+import socket
 from io import BytesIO
 from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
@@ -119,7 +120,21 @@ class ElegooPrinterApiClient:
             )
             return False
 
-        # Try direct IP first (more efficient for cross-subnet)
+        discovery_addresses = {printer.ip_address}
+        try:
+            resolved_address = await self.hass.async_add_executor_job(
+                socket.gethostbyname, printer.ip_address
+            )
+        except socket.gaierror as e:
+            self._logger.debug(
+                "Could not resolve configured printer address %s: %s",
+                printer.ip_address,
+                e,
+            )
+        else:
+            discovery_addresses.add(resolved_address)
+
+        # Try the configured address first (more efficient for cross-subnet)
         printer_reachable = False
 
         try:
@@ -132,7 +147,7 @@ class ElegooPrinterApiClient:
                 self.client.discover_printer, printer.ip_address
             )
             printer_reachable = any(
-                p.ip_address == printer.ip_address for p in discovered_printers
+                p.ip_address in discovery_addresses for p in discovered_printers
             )
         except (OSError, RuntimeError, TimeoutError) as e:
             self._logger.debug(
@@ -153,7 +168,7 @@ class ElegooPrinterApiClient:
                     self.client.discover_printer
                 )
                 printer_reachable = any(
-                    p.ip_address == printer.ip_address for p in discovered_printers
+                    p.ip_address in discovery_addresses for p in discovered_printers
                 )
             except (OSError, RuntimeError, TimeoutError) as e:
                 self._logger.warning(

--- a/custom_components/elegoo_printer/config_flow.py
+++ b/custom_components/elegoo_printer/config_flow.py
@@ -1239,6 +1239,7 @@ class ElegooOptionsFlowHandler(config_entries.OptionsFlow):
         LOGGER.debug("options: %s", self.config_entry.options)
 
         if user_input is not None:
+            printer.ip_address = user_input[CONF_IP_ADDRESS]
             if not user_input[CONF_PROXY_ENABLED]:
                 printer.proxy_websocket_port = None
                 printer.proxy_video_port = None

--- a/custom_components/elegoo_printer/tests/test_api_discovery.py
+++ b/custom_components/elegoo_printer/tests/test_api_discovery.py
@@ -1,0 +1,101 @@
+"""Tests for WebSocket printer discovery matching."""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+from custom_components.elegoo_printer.api import ElegooPrinterApiClient
+from custom_components.elegoo_printer.sdcp.models.printer import Printer
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_DOC_IP = "192.0.2.10"
+_HOSTNAME = "centauri-carbon.local"
+
+
+def _printer(ip_address: str) -> Printer:
+    return Printer.from_dict(
+        {
+            "name": "Centauri Carbon",
+            "ip_address": ip_address,
+            "protocol": "V3",
+        }
+    )
+
+
+def _api_client(discovered_printers: list[Printer]) -> ElegooPrinterApiClient:
+    api_client = ElegooPrinterApiClient.__new__(ElegooPrinterApiClient)
+    api_client.client = MagicMock()
+    api_client.client.discover_printer.return_value = discovered_printers
+    api_client._logger = MagicMock()
+    api_client.hass = MagicMock()
+
+    async def _run_executor_job(func: Callable[..., Any], *args: Any) -> Any:
+        return func(*args)
+
+    api_client.hass.async_add_executor_job = AsyncMock(side_effect=_run_executor_job)
+    return api_client
+
+
+class TestDiscoverPrinterWithFallback:
+    """Hostname-aware WebSocket discovery."""
+
+    def test_resolved_hostname_matches_numeric_discovery_result(self) -> None:
+        async def _run() -> None:
+            api_client = _api_client([_printer(_DOC_IP)])
+            with patch(
+                "custom_components.elegoo_printer.api.socket.gethostbyname",
+                return_value=_DOC_IP,
+            ) as resolve_hostname:
+                assert await api_client._discover_printer_with_fallback(
+                    _printer(_HOSTNAME)
+                )
+
+            resolve_hostname.assert_called_once_with(_HOSTNAME)
+            api_client.client.discover_printer.assert_called_once_with(_HOSTNAME)
+
+        asyncio.run(_run())
+
+    def test_resolved_hostname_matches_broadcast_discovery_result(self) -> None:
+        async def _run() -> None:
+            api_client = _api_client([])
+            api_client.client.discover_printer.side_effect = [
+                [],
+                [_printer(_DOC_IP)],
+            ]
+            with patch(
+                "custom_components.elegoo_printer.api.socket.gethostbyname",
+                return_value=_DOC_IP,
+            ):
+                assert await api_client._discover_printer_with_fallback(
+                    _printer(_HOSTNAME)
+                )
+
+            assert api_client.client.discover_printer.call_args_list == [
+                call(_HOSTNAME),
+                call(),
+            ]
+
+        asyncio.run(_run())
+
+    def test_unresolvable_hostname_still_uses_broadcast_fallback(self) -> None:
+        async def _run() -> None:
+            api_client = _api_client([])
+            with patch(
+                "custom_components.elegoo_printer.api.socket.gethostbyname",
+                side_effect=socket.gaierror,
+            ):
+                assert not await api_client._discover_printer_with_fallback(
+                    _printer(_HOSTNAME)
+                )
+
+            assert api_client.client.discover_printer.call_args_list == [
+                call(_HOSTNAME),
+                call(),
+            ]
+
+        asyncio.run(_run())

--- a/custom_components/elegoo_printer/tests/test_config_flow_websocket_options.py
+++ b/custom_components/elegoo_printer/tests/test_config_flow_websocket_options.py
@@ -1,0 +1,65 @@
+"""Tests for WebSocket printer options."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.const import CONF_IP_ADDRESS
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.elegoo_printer.config_flow import ElegooOptionsFlowHandler
+from custom_components.elegoo_printer.const import CONF_PROXY_ENABLED
+from custom_components.elegoo_printer.sdcp.models.printer import Printer
+
+_DOC_IP = "192.0.2.10"
+_HOSTNAME = "centauri-carbon.local"
+
+WEBSOCKET_ENTRY_DATA = {
+    "name": "Centauri Carbon",
+    "ip_address": _DOC_IP,
+    "transport_type": "websocket",
+    "protocol_version": "V3",
+    "protocol": "V3",
+    "id": "test-board-id",
+    "model": "Centauri Carbon",
+}
+
+
+def _make_options_flow() -> ElegooOptionsFlowHandler:
+    entry = MagicMock()
+    entry.data = dict(WEBSOCKET_ENTRY_DATA)
+    entry.options = {}
+    flow = ElegooOptionsFlowHandler(entry)
+    flow.hass = MagicMock()
+    flow.flow_id = "options-test-flow"
+    flow.handler = "elegoo_printer"
+    return flow
+
+
+class TestAsyncStepWebsocketOptions:
+    """WebSocket options connection validation."""
+
+    def test_connection_uses_submitted_hostname(self) -> None:
+        async def _run() -> None:
+            flow = _make_options_flow()
+            tested_printer = Printer.from_dict(
+                {**WEBSOCKET_ENTRY_DATA, "ip_address": _HOSTNAME}
+            )
+
+            with patch(
+                "custom_components.elegoo_printer.config_flow._async_test_connection",
+                new=AsyncMock(return_value=tested_printer),
+            ) as test_connection:
+                result = await flow.async_step_websocket_options(
+                    user_input={
+                        CONF_IP_ADDRESS: _HOSTNAME,
+                        CONF_PROXY_ENABLED: False,
+                    }
+                )
+
+            assert result["type"] == FlowResultType.CREATE_ENTRY
+            submitted_printer = test_connection.await_args.args[1]
+            assert submitted_printer.ip_address == _HOSTNAME
+
+        asyncio.run(_run())


### PR DESCRIPTION
## Summary

- resolve configured WebSocket printer hostnames before comparing discovery results
- accept the configured hostname or its resolved IPv4 address for direct and broadcast discovery
- keep discovery working when DNS resolution fails
- validate the newly submitted address in the WebSocket options flow
- document hostname support for manual configuration

## Problem

When a printer is configured by hostname, discovery returns the printer numeric IPv4 address. The integration compared that response literally with the configured hostname and rejected the reachable printer. The WebSocket options flow also tested the previously stored address instead of the newly submitted one.

## Testing

- uv run ruff format .
- uv run ruff check .
- uv run pytest (303 passed)
