### PR TITLE
Feat: active_tray_id sensor

### DIFF
--- a/custom_components/elegoo_printer/definitions.py
+++ b/custom_components/elegoo_printer/definitions.py
@@ -72,7 +72,11 @@ def _get_active_tray_id(printer_data: PrinterData) -> str | None:
     active = printer_data.ams_status.ams_current_enabled
     if not active:
         return None
-    return active.get("TrayId")
+    tray_id = active.get("TrayId")
+    # CC1 reports -1 when idle (no filament feeding)
+    if tray_id is not None and tray_id.startswith("-"):
+        return None
+    return tray_id
 
 
 def _get_active_filament_color(printer_data: PrinterData) -> str | None:

--- a/custom_components/elegoo_printer/definitions.py
+++ b/custom_components/elegoo_printer/definitions.py
@@ -65,6 +65,16 @@ def _get_current_coord_value(printer_data: PrinterData, index: int) -> float | N
         return None
 
 
+def _get_active_tray_id(printer_data: PrinterData) -> str | None:
+    """Get the tray ID of the currently active filament."""
+    if not printer_data or not printer_data.ams_status:
+        return None
+    active = printer_data.ams_status.ams_current_enabled
+    if not active:
+        return None
+    return active.get("TrayId")
+
+
 def _get_active_filament_color(printer_data: PrinterData) -> str | None:
     """Get the hex color of the currently active filament."""
     if not printer_data or not printer_data.ams_status:
@@ -1031,6 +1041,12 @@ PRINTER_STATUS_CANVAS: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         extra_attributes=lambda entity: _get_active_filament_attributes(
             entity.coordinator.data
         ),
+    ),
+    ElegooPrinterSensorEntityDescription(
+        key="active_tray_id",
+        name="Active Tray ID",
+        icon="mdi:tray-full",
+        value_fn=lambda printer_data: _get_active_tray_id(printer_data),
     ),
     # --- A1-A4 Color ---
     *(

--- a/custom_components/elegoo_printer/definitions.py
+++ b/custom_components/elegoo_printer/definitions.py
@@ -1046,7 +1046,7 @@ PRINTER_STATUS_CANVAS: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         key="active_tray_id",
         name="Active Tray ID",
         icon="mdi:tray-full",
-        value_fn=lambda printer_data: _get_active_tray_id(printer_data),
+        value_fn=_get_active_tray_id,
     ),
     # --- A1-A4 Color ---
     *(

--- a/custom_components/elegoo_printer/tests/test_extruder_sensors.py
+++ b/custom_components/elegoo_printer/tests/test_extruder_sensors.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from custom_components.elegoo_printer.definitions import (
     PRINTER_STATUS_CANVAS,
     PRINTER_STATUS_CC2_GCODE_FILAMENT,
     PRINTER_STATUS_GCODE_PROXY_FILAMENT,
+    _get_active_tray_id,
     _get_slot_attributes,
     _get_slot_cm3,
     _get_slot_color,
@@ -325,6 +328,43 @@ class TestGetTotalFilamentUsedAttributes:
         assert attrs["filename"] == "only_name.gcode"
         assert "print_time_sec" not in attrs
         assert "color_map" not in attrs
+
+
+class TestGetActiveTrayId:
+    """active_tray_id returns the padded tray ID or None."""
+
+    @pytest.mark.parametrize(
+        ("active_tray_id", "expected"),
+        [
+            (0, "00"),
+            (1, "01"),
+            (3, "03"),
+            (-1, None),
+        ],
+        ids=["tray_zero", "tray_one", "tray_three", "idle_sentinel"],
+    )
+    def test_active_tray_value(self, active_tray_id: int, expected: str | None) -> None:
+        """Valid trays return zero-padded ID; CC1 idle sentinel (-1) returns None."""
+        data = {
+            **CANVAS_TRAY_DATA,
+            "active_canvas_id": 0,
+            "active_tray_id": active_tray_id,
+        }
+        pd = _make_printer_data(ams_status=AMSStatus(data))
+        assert _get_active_tray_id(pd) == expected
+
+    @pytest.mark.parametrize(
+        "printer_data",
+        [
+            _make_printer_data(ams_status=AMSStatus(CANVAS_TRAY_DATA)),
+            _make_printer_data(),
+            None,
+        ],
+        ids=["no_active_tray", "no_ams", "none_printer_data"],
+    )
+    def test_missing_data_returns_none(self, printer_data: PrinterData | None) -> None:
+        """Returns None when active tray, AMS, or printer data is absent."""
+        assert _get_active_tray_id(printer_data) is None
 
 
 class TestFilamentSensorAvailability:

--- a/custom_components/elegoo_printer/tests/test_sensor_registration.py
+++ b/custom_components/elegoo_printer/tests/test_sensor_registration.py
@@ -10,6 +10,7 @@ import pytest
 from custom_components.elegoo_printer.definitions import (
     _FDM_PRINT_STATUS_OPTIONS,
     _RESIN_PRINT_STATUS_OPTIONS,
+    PRINTER_STATUS_CANVAS,
     PRINTER_STATUS_CC2_GCODE_FILAMENT,
     PRINTER_STATUS_FDM,
     PRINTER_STATUS_FDM_CURRENT_EXTRUSION,
@@ -23,6 +24,7 @@ from custom_components.elegoo_printer.sdcp.models.enums import (
 )
 from custom_components.elegoo_printer.sensor import async_setup_entry
 
+CANVAS_KEYS = {desc.key for desc in PRINTER_STATUS_CANVAS}
 CURRENT_EXTRUSION_KEYS = {desc.key for desc in PRINTER_STATUS_FDM_CURRENT_EXTRUSION}
 TOTAL_EXTRUSION_KEYS = {desc.key for desc in PRINTER_STATUS_FDM_TOTAL_EXTRUSION}
 GCODE_FILAMENT_KEYS = {desc.key for desc in PRINTER_STATUS_CC2_GCODE_FILAMENT}
@@ -41,6 +43,7 @@ def _registered_keys(
     protocol_version: ProtocolVersion,
     *,
     open_centauri: bool,
+    has_canvas: bool = False,
     config_data: dict | None = None,
 ) -> set[str]:
     """Call the real async_setup_entry and return the set of registered sensor keys."""
@@ -48,6 +51,7 @@ def _registered_keys(
     printer.printer_type = printer_type
     printer.protocol_version = protocol_version
     printer.open_centauri = open_centauri
+    printer.has_canvas = has_canvas
     printer.has_vat_heater = False
 
     coordinator = MagicMock()
@@ -268,3 +272,40 @@ class TestPrintStatusOptionsScoping:
     def test_resin_options_subset_of_fdm(self) -> None:
         """Every resin option is also a valid FDM option."""
         assert set(_RESIN_PRINT_STATUS_OPTIONS).issubset(_FDM_PRINT_STATUS_OPTIONS)
+
+
+class TestCanvasGating:
+    """Test Canvas sensor inclusion via async_setup_entry."""
+
+    def test_canvas_keys_include_active_tray_id(self) -> None:
+        """Verify active_tray_id is in the Canvas sensor tuple."""
+        assert "active_tray_id" in CANVAS_KEYS
+
+    @pytest.mark.parametrize(
+        ("printer_type", "protocol_version", "has_canvas", "expected"),
+        [
+            (PrinterType.FDM, ProtocolVersion.CC2, True, True),
+            (PrinterType.FDM, ProtocolVersion.V3, True, True),
+            (PrinterType.FDM, ProtocolVersion.V1, True, True),
+            (PrinterType.FDM, ProtocolVersion.CC2, False, False),
+            (PrinterType.FDM, ProtocolVersion.V3, False, False),
+            (PrinterType.FDM, ProtocolVersion.V1, False, False),
+            (PrinterType.RESIN, ProtocolVersion.V3, True, False),
+            (PrinterType.RESIN, ProtocolVersion.CC2, True, False),
+            (None, ProtocolVersion.CC2, True, False),
+            (None, ProtocolVersion.V3, True, False),
+        ],
+    )
+    def test_canvas_gating(
+        self,
+        printer_type: PrinterType | None,
+        protocol_version: ProtocolVersion,
+        has_canvas: bool,  # noqa: FBT001
+        expected: bool,  # noqa: FBT001
+    ) -> None:
+        """Test Canvas sensor inclusion for various printer configurations."""
+        keys = _registered_keys(
+            printer_type, protocol_version,
+            open_centauri=False, has_canvas=has_canvas,
+        )
+        assert CANVAS_KEYS.issubset(keys) == expected

--- a/custom_components/elegoo_printer/tests/test_sensor_registration.py
+++ b/custom_components/elegoo_printer/tests/test_sensor_registration.py
@@ -305,7 +305,9 @@ class TestCanvasGating:
     ) -> None:
         """Test Canvas sensor inclusion for various printer configurations."""
         keys = _registered_keys(
-            printer_type, protocol_version,
-            open_centauri=False, has_canvas=has_canvas,
+            printer_type,
+            protocol_version,
+            open_centauri=False,
+            has_canvas=has_canvas,
         )
         assert CANVAS_KEYS.issubset(keys) == expected


### PR DESCRIPTION
The active tray ID was only available as an attribute buried on the
active_filament_color sensor, which meant it had no HA history of its
own. Promoting it to a sensor instead of an attribute, enables time-series
tracking of tray changes during multi-material prints.

Addresses #395