### PR TITLE
fix(camera): release printer video stream after last viewer disconnects (#399)

### DIFF
--- a/custom_components/elegoo_printer/camera.py
+++ b/custom_components/elegoo_printer/camera.py
@@ -42,7 +42,6 @@ from .coordinator import ElegooDataUpdateCoordinator
 if TYPE_CHECKING:
     from custom_components.elegoo_printer.websocket.client import ElegooPrinterClient
 
-
 # Graceful ffmpeg shutdown timeouts
 FFMPEG_QUIT_TIMEOUT = 10  # seconds to wait after sending 'q' to ffmpeg
 FFMPEG_TERMINATE_TIMEOUT = 5  # seconds to wait after SIGTERM before SIGKILL
@@ -108,6 +107,200 @@ class ElegooCameraMjpeg(CameraMjpeg):
         self._clear()
 
 
+class ElegooVideoStreamLifecycle(ElegooPrinterEntity):
+    """
+    Ref-counted lifecycle for the printer's video stream.
+
+    Printers advertise a fixed number of concurrent video stream
+    connections (num_video_stream_connected vs. max_video_stream_allowed)
+    and once the stream is enabled it stays active on the printer side
+    until explicitly disabled. Leaving it enabled with no viewers occupies
+    a slot (which can block other consumers and requires a printer reboot
+    to release), so this mixin:
+
+    - Enables the video when the first viewer (MJPEG stream, transient
+      image grab, or native stream) appears
+    - Disables it when the last viewer disconnects
+    - An idle watchdog re-attempts failed disables and clears stale
+      native stream flags
+    - Disables on entity removal to clean up residual state
+
+    The mixin does not own entity state. Camera classes call
+    ``_init_video_lifecycle(client)`` inside their own ``__init__`` once
+    ``self._printer_client`` is available.
+    """
+
+    def _init_video_lifecycle(self, client: "ElegooPrinterClient") -> None:
+        """Initialize stream lifecycle state on this camera entity."""
+        self._printer_client = client
+        self._active_mjpeg_streams = 0
+        self._transient_viewers = 0
+        self._native_stream_active = False
+        self._stream_enabled = False
+        self._last_activity = 0.0
+        self._idle_watchdog_task = None
+
+    def _is_over_capacity(self) -> bool:
+        """Check if the printer is over capacity."""
+        attrs = self._printer_client.printer_data.attributes
+        num_connected = getattr(attrs, "num_video_stream_connected", 0) or 0
+        max_allowed = getattr(attrs, "max_video_stream_allowed", 0) or 0
+        return num_connected >= max_allowed
+
+    def _has_active_viewers(self) -> bool:
+        """Check if any viewer type is currently active."""
+        return (
+            self._active_mjpeg_streams > 0
+            or self._transient_viewers > 0
+            or self._native_stream_active
+        )
+
+    async def _ensure_stream_enabled(self) -> None:
+        """
+        Enable printer video if not already enabled.
+
+        Idempotent — safe to call when already enabled.
+        On failure, _stream_enabled is NOT set (may retry later).
+        """
+        if self._stream_enabled:
+            return
+        if not self._printer_client.is_connected:
+            LOGGER.debug(
+                "Printer client not connected, deferring video enable for %s",
+                self.entity_id,
+            )
+            return
+        try:
+            video = await self._printer_client.get_printer_video(enable=True)
+        except Exception as e:  # noqa: BLE001
+            LOGGER.warning(
+                "Exception enabling printer video for %s: %s",
+                self.entity_id,
+                e,
+            )
+            return
+        if video.status == ElegooVideoStatus.SUCCESS:
+            self._stream_enabled = True
+            LOGGER.debug("Enabled printer video for %s", self.entity_id)
+        else:
+            LOGGER.warning(
+                "Failed to enable printer video for %s: %s",
+                self.entity_id,
+                video.status,
+            )
+
+    async def _disable_stream(self) -> None:
+        """
+        Disable printer video.
+
+        On failure, _stream_enabled stays True (video may still be on
+        printer). The idle watchdog will re-attempt on subsequent
+        intervals.
+        """
+        if not self._stream_enabled:
+            return
+        try:
+            await self._printer_client.set_printer_video_stream(enable=False)
+        except Exception as e:  # noqa: BLE001
+            LOGGER.warning(
+                "Failed to disable printer video for %s (may be over capacity): %s",
+                self.entity_id,
+                e,
+            )
+            # Don't clear flag — video may still be enabled on printer
+            return
+        self._stream_enabled = False
+        LOGGER.debug("Disabled printer video for %s", self.entity_id)
+
+    async def _get_stream_url(self) -> str | None:
+        """
+        Get the stream URL from cached printer data.
+
+        Does NOT toggle the printer video — reads the URL cached by the
+        last call to get_printer_video(). Callers must ensure the video
+        is enabled via _ensure_stream_enabled() before calling this method.
+        """
+        if (not self._printer_client.is_connected) or self._is_over_capacity():
+            return None
+        video_url = self._printer_client.printer_data.video.video_url
+        if video_url:
+            LOGGER.debug(
+                "stream_source: Using cached stream URL: %s",
+                video_url,
+            )
+            return video_url
+        return None
+
+    async def _idle_watchdog_tick(self) -> None:
+        """
+        Run a single watchdog pass.
+
+        1. If no viewers are active and video is enabled, attempt to
+           disable it (handles failed disables from the normal
+           disconnect path).
+        2. If the native stream has been idle for
+           NATIVE_STREAM_IDLE_TIMEOUT, clear the native-stream flag
+           (allows a future disable attempt).
+        """
+        if self._stream_enabled and not self._has_active_viewers():
+            await self._disable_stream()
+        if (
+            self._native_stream_active
+            and self._last_activity > 0
+            and asyncio.get_running_loop().time() - self._last_activity
+            > NATIVE_STREAM_IDLE_TIMEOUT
+        ):
+            LOGGER.debug(
+                "Native stream idle for %.0fs, clearing flag for %s",
+                NATIVE_STREAM_IDLE_TIMEOUT,
+                self.entity_id,
+            )
+            self._native_stream_active = False
+
+    async def _idle_watchdog(self) -> None:
+        """
+        Periodically check for idle conditions and clean up.
+
+        Runs every IDLE_WATCHDOG_INTERVAL seconds. See the tick for the
+        two responsibilities (disabled-when-idle, stale native flag).
+        """
+        while True:
+            try:
+                await asyncio.sleep(IDLE_WATCHDOG_INTERVAL)
+                await self._idle_watchdog_tick()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                LOGGER.exception("Idle watchdog error for %s", self.entity_id)
+
+    async def _cleanup_video_lifecycle(self) -> None:
+        """Cancel the idle watchdog and release the video stream state."""
+        if self._idle_watchdog_task is not None:
+            self._idle_watchdog_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._idle_watchdog_task
+            self._idle_watchdog_task = None
+        self._active_mjpeg_streams = 0
+        self._transient_viewers = 0
+        self._native_stream_active = False
+        await self._disable_stream()
+
+    async def async_added_to_hass(self) -> None:
+        """Start the idle watchdog when the entity is added."""
+        await super().async_added_to_hass()
+        self._idle_watchdog_task = asyncio.create_task(self._idle_watchdog())
+
+    async def async_will_remove_from_hass(self) -> None:
+        """
+        Clean up when the entity is removed from Home Assistant.
+
+        Cancels the idle watchdog, resets stream state and disables the
+        printer video.
+        """
+        await super().async_will_remove_from_hass()
+        await self._cleanup_video_lifecycle()
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ElegooPrinterConfigEntry,
@@ -132,7 +325,7 @@ async def async_setup_entry(
             )
 
 
-class ElegooStreamCamera(ElegooPrinterEntity, Camera):
+class ElegooStreamCamera(ElegooVideoStreamLifecycle, Camera):
     """Representation of a camera that streams from an Elegoo printer."""
 
     def __init__(
@@ -159,102 +352,13 @@ class ElegooStreamCamera(ElegooPrinterEntity, Camera):
         self._extra_ffmpeg_arguments = (
             "-rtsp_transport udp -fflags nobuffer -err_detect ignore_err"
         )
-
-        # Stream lifecycle tracking
-        self._active_mjpeg_streams: int = 0
         self._active_mjpeg_processes: set[ElegooCameraMjpeg] = set()
-        self._transient_viewers: int = 0  # async_camera_image grabs
-        self._native_stream_active: bool = False
-        self._stream_enabled: bool = False
-        self._last_activity: float = 0.0  # monotonic time of last stream activity
-        self._idle_watchdog_task: asyncio.Task | None = None
-
-    def _is_over_capacity(self) -> bool:
-        """Check if the printer is over capacity."""
-        attrs = self._printer_client.printer_data.attributes
-        num_connected = getattr(attrs, "num_video_stream_connected", 0) or 0
-        max_allowed = getattr(attrs, "max_video_stream_allowed", 0) or 0
-        return num_connected >= max_allowed
+        self._init_video_lifecycle(self._printer_client)
 
     @cached_property
     def supported_features(self) -> CameraEntityFeature:
         """Return supported features."""
         return self._attr_supported_features
-
-    def _has_active_viewers(self) -> bool:
-        """Check if any viewer type is currently active."""
-        return (
-            self._active_mjpeg_streams > 0
-            or self._transient_viewers > 0
-            or self._native_stream_active
-        )
-
-    async def _ensure_stream_enabled(self) -> None:
-        """
-        Enable printer video if not already enabled.
-
-        Idempotent — safe to call when already enabled.
-        On failure, _stream_enabled is NOT set (may retry later).
-        """
-        if self._stream_enabled:
-            return
-        try:
-            video = await self._printer_client.get_printer_video(enable=True)
-            if video.status == ElegooVideoStatus.SUCCESS:
-                self._stream_enabled = True
-                LOGGER.debug("Enabled printer video for %s", self.entity_id)
-            else:
-                LOGGER.warning(
-                    "Failed to enable printer video for %s: %s",
-                    self.entity_id,
-                    video.status,
-                )
-        except Exception as e:  # noqa: BLE001
-            LOGGER.warning(
-                "Exception enabling printer video for %s: %s",
-                self.entity_id,
-                e,
-            )
-
-    async def _disable_stream(self) -> None:
-        """
-        Disable printer video.
-
-        On failure, _stream_enabled stays True (video may still be on printer).
-        The idle watchdog will re-attempt on subsequent intervals.
-        """
-        if not self._stream_enabled:
-            return
-        try:
-            await self._printer_client.set_printer_video_stream(enable=False)
-            self._stream_enabled = False
-            LOGGER.debug("Disabled printer video for %s", self.entity_id)
-        except Exception as e:  # noqa: BLE001
-            LOGGER.warning(
-                "Failed to disable printer video for %s (may be over capacity): %s",
-                self.entity_id,
-                e,
-            )
-            # Don't clear flag — video may still be enabled on printer
-
-    async def _get_stream_url(self) -> str | None:
-        """
-        Get the stream URL from cached printer data.
-
-        Does NOT toggle the printer video — reads the URL cached by the
-        last call to get_printer_video(). Callers must ensure the video
-        is enabled via _ensure_stream_enabled() before calling this method.
-        """
-        if (not self._printer_client.is_connected) or self._is_over_capacity():
-            return None
-        video_url = self._printer_client.printer_data.video.video_url
-        if video_url:
-            LOGGER.debug(
-                "stream_source: Resin printer video (RTSP), using direct URL: %s",
-                video_url,
-            )
-            return video_url
-        return None
 
     async def handle_async_mjpeg_stream(
         self, request: web.Request
@@ -334,8 +438,8 @@ class ElegooStreamCamera(ElegooPrinterEntity, Camera):
         """
         Return a still image from the camera.
 
-        Treats the image grab as a transient viewer — enables video if needed,
-        but only disables if no other viewers are active.
+        Treats the image grab as a transient viewer — enables video if
+        needed, but only disables if no other viewers are active.
 
         Note: This path uses HA's async_get_image() which spawns its own
         ffmpeg process. That process does NOT get graceful SIGTERM shutdown,
@@ -366,81 +470,21 @@ class ElegooStreamCamera(ElegooPrinterEntity, Camera):
             if not self._has_active_viewers():
                 await self._disable_stream()
 
-    async def async_added_to_hass(self) -> None:
-        """Start the idle watchdog when the entity is added."""
-        await super().async_added_to_hass()
-        self._idle_watchdog_task = asyncio.create_task(self._idle_watchdog())
-
-    async def _idle_watchdog(self) -> None:
-        """
-        Periodically check for idle conditions and clean up.
-
-        Runs every IDLE_WATCHDOG_INTERVAL seconds. Two responsibilities:
-        1. If no viewers are active and video is enabled, attempt to disable
-           (handles failed disables from normal disconnect path).
-        2. If native stream has been idle for NATIVE_STREAM_IDLE_TIMEOUT,
-           clear the native stream flag (allows future disable attempts).
-
-        Limitation: We cannot detect when HA's native stream stops (no callback).
-        The idle timeout is a best-effort heuristic. If a native stream is
-        actively consuming the RTSP feed when the flag is cleared, the next
-        watchdog tick (~60s later) will disable the video. This is acceptable
-        because STREAM is not advertised in supported_features, so this path
-        is not actively used.
-        """
-        loop = asyncio.get_running_loop()
-        while True:
-            try:
-                await asyncio.sleep(IDLE_WATCHDOG_INTERVAL)
-                # Always attempt disable if video is on but no viewers
-                if self._stream_enabled and not self._has_active_viewers():
-                    await self._disable_stream()
-                # Clear native stream flag if idle (next tick will disable)
-                if (
-                    self._native_stream_active
-                    and self._last_activity > 0
-                    and loop.time() - self._last_activity > NATIVE_STREAM_IDLE_TIMEOUT
-                ):
-                    LOGGER.debug(
-                        "Native stream idle for %.0fs, clearing flag for %s",
-                        NATIVE_STREAM_IDLE_TIMEOUT,
-                        self.entity_id,
-                    )
-                    self._native_stream_active = False
-            except asyncio.CancelledError:
-                raise
-            except Exception:  # noqa: BLE001
-                LOGGER.exception("Idle watchdog error for %s", self.entity_id)
-
     async def async_will_remove_from_hass(self) -> None:
         """
         Clean up when the entity is removed from Home Assistant.
 
-        Cancels the idle watchdog, closes any in-flight MJPEG processes,
-        and disables the printer video.
+        Closes any in-flight MJPEG processes (camera-specific state),
+        then delegates to the lifecycle for watchdog cancellation and
+        stream disabling.
         """
-        # Cancel idle watchdog
-        if self._idle_watchdog_task:
-            self._idle_watchdog_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._idle_watchdog_task
-            self._idle_watchdog_task = None
-
-        # Close any in-flight MJPEG processes
         for proc in self._active_mjpeg_processes.copy():
             await proc.close(shutdown_timeout=FFMPEG_QUIT_TIMEOUT)
         self._active_mjpeg_processes.clear()
-        self._active_mjpeg_streams = 0
-        self._transient_viewers = 0
-
-        # Disable native stream tracking
-        self._native_stream_active = False
-
-        # Disable printer video
-        await self._disable_stream()
+        await super().async_will_remove_from_hass()
 
 
-class ElegooMjpegCamera(ElegooPrinterEntity, MjpegCamera):
+class ElegooMjpegCamera(ElegooVideoStreamLifecycle, MjpegCamera):
     """Representation of an MjpegCamera."""
 
     def __init__(
@@ -482,13 +526,7 @@ class ElegooMjpegCamera(ElegooPrinterEntity, MjpegCamera):
         self._printer_client: ElegooPrinterClient = (
             coordinator.config_entry.runtime_data.api.client
         )
-
-    def _is_over_capacity(self) -> bool:
-        """Check if the printer is over capacity."""
-        attrs = self._printer_client.printer_data.attributes
-        num_connected = getattr(attrs, "num_video_stream_connected", 0) or 0
-        max_allowed = getattr(attrs, "max_video_stream_allowed", 0) or 0
-        return num_connected >= max_allowed
+        self._init_video_lifecycle(self._printer_client)
 
     @staticmethod
     def _normalize_video_url(video_url: str | None) -> str | None:
@@ -515,41 +553,101 @@ class ElegooMjpegCamera(ElegooPrinterEntity, MjpegCamera):
         return video_url
 
     async def _update_stream_url(self) -> None:
-        """Update the MJPEG stream URL."""
+        """
+        Update the MJPEG stream URL and manage video state.
+
+        Ref-counted like the rest of the lifecycle: the update is
+        re-requested only when the video is not enabled, or when the
+        video is enabled but the URL is mismatched (retries are safe
+        because an already-enabled stream tolerates a subsequent enable).
+        Over-capacity/disconnected printers are left untouched.
+        """
+        if self._stream_enabled and self._mjpeg_url:
+            # URL still valid from when the stream was enabled
+            return
         if (not self._printer_client.is_connected) or self._is_over_capacity():
+            self._mjpeg_url = None
             return
         video = await self._printer_client.get_printer_video(enable=True)
-        if video.status and video.status == ElegooVideoStatus.SUCCESS:
-            LOGGER.debug("stream_source: Video is OK, getting stream source")
+        if video.status == ElegooVideoStatus.SUCCESS:
+            self._stream_enabled = True
             video_url = self._normalize_video_url(video.video_url)
+            self._mjpeg_url = video_url
             if not video_url:
                 LOGGER.debug("stream_source: Empty or invalid video URL from printer")
-                self._mjpeg_url = None
-                return
-
-            LOGGER.debug("stream_source: Using video url: %s", video_url)
-            self._mjpeg_url = video_url
+            else:
+                LOGGER.debug("stream_source: Using video url: %s", video_url)
         else:
             LOGGER.debug("stream_source: Failed to get video stream: %s", video.status)
+            self._stream_enabled = False
             self._mjpeg_url = None
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
-        """Asynchronously gets the current MJPEG stream URL for the printer camera."""
-        await self._update_stream_url()
-        if (not self._mjpeg_url) or self._is_over_capacity():
-            return None
-        return await super().async_camera_image(width=width, height=height)
+        """
+        Return a still image from the printer camera.
+
+        Treats the image grab as a transient viewer — ref-counts the
+        video stream per ElegooVideoStreamLifecycle: enables the stream
+        on the first viewer and disables it when the last viewer
+        disconnects. The base MjpegCamera image path reads a single
+        frame from a short-lived HTTP connection, which closes when the
+        grab completes, so no stream connection is left open afterwards.
+        """
+        # Enable stream if no other viewers are active (check before increment)
+        if not self._has_active_viewers():
+            await self._update_stream_url()
+        self._transient_viewers += 1
+        try:
+            if (not self._mjpeg_url) or self._is_over_capacity():
+                return None
+            return await super().async_camera_image(width=width, height=height)
+        finally:
+            self._transient_viewers = max(0, self._transient_viewers - 1)
+            # Only disable if no other viewers are active
+            if not self._has_active_viewers():
+                await self._disable_stream()
 
     async def handle_async_mjpeg_stream(
         self, request: web.Request
     ) -> web.StreamResponse:
-        """Generate an HTTP MJPEG stream from the camera."""
-        await self._update_stream_url()
-        if not self._mjpeg_url:
-            return web.Response(
-                status=HTTPStatus.SERVICE_UNAVAILABLE,
-                reason="Stream URL not available",
-            )
-        return await super().handle_async_mjpeg_stream(request)
+        """
+        Generate an HTTP MJPEG stream from the camera.
+
+        Ref-counted: enables video on first viewer, disables on last.
+        """
+        # Enable stream if first viewer
+        if not self._has_active_viewers():
+            await self._update_stream_url()
+        self._active_mjpeg_streams += 1
+        self._last_activity = asyncio.get_running_loop().time()
+        try:
+            if not self._mjpeg_url or self._is_over_capacity():
+                return web.Response(
+                    status=HTTPStatus.SERVICE_UNAVAILABLE,
+                    reason="Stream URL not available",
+                )
+            return await super().handle_async_mjpeg_stream(request)
+        finally:
+            # Disable stream if last viewer
+            self._last_activity = asyncio.get_running_loop().time()
+            self._active_mjpeg_streams = max(0, self._active_mjpeg_streams - 1)
+            if not self._has_active_viewers():
+                await self._disable_stream()
+
+    async def stream_source(self) -> str | None:
+        """
+        Return the MJPEG stream source.
+
+        Enables video for native streams (which uses the MJPEG source
+        with FFmpeg), tracks the stream, and disables it after
+        NATIVE_STREAM_IDLE_TIMEOUT of idle via the idle watchdog.
+        """
+        if not self._native_stream_active:
+            await self._update_stream_url()
+            if not self._mjpeg_url:
+                return None
+            self._native_stream_active = True
+            self._last_activity = asyncio.get_running_loop().time()
+        return self._mjpeg_url

--- a/custom_components/elegoo_printer/tests/test_video_lifecycle.py
+++ b/custom_components/elegoo_printer/tests/test_video_lifecycle.py
@@ -1,0 +1,587 @@
+"""
+Tests for the video stream lifecycle management (documented in issue #399).
+
+Covers the shared ElegooVideoStreamLifecycle mixin, the FDM
+ElegooMjpegCamera (the class reported to leak video stream sessions), and
+the resin ElegooStreamCamera regression check.
+"""
+
+import asyncio
+import contextlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.components.mjpeg.camera import MjpegCamera
+
+import custom_components.elegoo_printer.camera as camera_module
+from custom_components.elegoo_printer.camera import (
+    ElegooMjpegCamera,
+    ElegooStreamCamera,
+    ElegooVideoStreamLifecycle,
+)
+from custom_components.elegoo_printer.sdcp.models.enums import ElegooVideoStatus
+
+REQUEST = MagicMock()  # web.Request stand-in
+
+
+def _run(coro):
+    """Run an async coroutine to completion (fresh loop)."""
+    asyncio.run(coro)
+
+
+class _VideoLifecycleSubject(ElegooVideoStreamLifecycle):
+    """Bare lifecycle subject, bypassing entity/camera machinery."""
+
+    def __init__(
+        self,
+        client: MagicMock,
+        *,
+        entity_id: str = "camera.test",
+    ) -> None:
+        self.entity_id = entity_id
+        self._init_video_lifecycle(client)
+
+
+def _make_client(
+    *,
+    connected: bool = True,
+    over_capacity: bool = False,
+) -> tuple[MagicMock, MagicMock]:
+    """
+    Build a mock printer client with a video object.
+
+    Returns:
+        (client, video) — video.parameters can be set per test to make
+        status checks pass/fail.
+
+    """
+    client = MagicMock()
+    client.is_connected = connected
+    client.printer_data = MagicMock()
+    attrs = client.printer_data.attributes
+    attrs.num_video_stream_connected = 2 if over_capacity else 0
+    attrs.max_video_stream_allowed = 1
+    video = MagicMock()
+    video.status = ElegooVideoStatus.SUCCESS
+    video.video_url = "127.0.0.1:8080/mjpeg"
+    client.printer_data.video = video
+    client.get_printer_video = AsyncMock(return_value=video)
+    client.set_printer_video_stream = AsyncMock()
+    return client, video
+
+
+def _fdm_camera(client: MagicMock) -> ElegooMjpegCamera:
+    """Build an ElegooMjpegCamera object without full entity init."""
+    cam = object.__new__(ElegooMjpegCamera)
+    cam.hass = MagicMock()
+    cam.entity_id = "camera.test"
+    cam._mjpeg_url = None
+    cam._init_video_lifecycle(client)
+    return cam
+
+
+def _resin_camera(client: MagicMock) -> ElegooStreamCamera:
+    """Build an ElegooStreamCamera object without full entity init."""
+    cam = object.__new__(ElegooStreamCamera)
+    cam.hass = MagicMock()
+    cam.entity_id = "camera.test"
+    cam.entity_description = MagicMock(key="chamber_camera")
+    cam._extra_ffmpeg_arguments = "-rtsp_transport udp"
+    cam._active_mjpeg_processes: set = set()
+    cam._init_video_lifecycle(client)
+    return cam
+
+
+class TestVideoLifecycleMixin:
+    """Shared ref-counted lifecycle behaviour."""
+
+    def test_initial_state_disabled(self) -> None:
+        """Stream starts disabled with zero viewers."""
+        client, _ = _make_client()
+        subject = _VideoLifecycleSubject(client)
+        assert subject._stream_enabled is False
+        assert subject._active_mjpeg_streams == 0
+        assert subject._transient_viewers == 0
+        assert subject._native_stream_active is False
+
+    def test_ensure_enabled_sends_enable_and_sets_flag(self) -> None:
+        """First enable sends get_printer_video(enable=True)."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            subject = _VideoLifecycleSubject(client)
+            await subject._ensure_stream_enabled()
+            client.get_printer_video.assert_called_once_with(enable=True)
+            assert subject._stream_enabled is True
+
+        _run(run())
+
+    def test_ensure_enabled_is_idempotent(self) -> None:
+        """Second call while enabled issues no further command."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            subject = _VideoLifecycleSubject(client)
+            subject._stream_enabled = True
+            await subject._ensure_stream_enabled()
+            client.get_printer_video.assert_not_called()
+
+        _run(run())
+
+    def test_ensure_enabled_skips_when_not_connected(self) -> None:
+        """No command is sent when the client is disconnected."""
+
+        async def run() -> None:
+            client, _ = _make_client(connected=False)
+            subject = _VideoLifecycleSubject(client)
+            await subject._ensure_stream_enabled()
+            client.get_printer_video.assert_not_called()
+            assert subject._stream_enabled is False
+
+        _run(run())
+
+    def test_ensure_enabled_failure_keeps_disabled(self) -> None:
+        """A non-success status means no flag and no disable later."""
+
+        async def run() -> None:
+            client, video = _make_client()
+            video.status = ElegooVideoStatus.UNKNOWN_ERROR
+            subject = _VideoLifecycleSubject(client)
+            await subject._ensure_stream_enabled()
+            assert subject._stream_enabled is False
+
+        _run(run())
+
+    def test_ensure_enabled_swallows_exception(self) -> None:
+        """A raised enable failure is logged, flag stays unset."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            client.get_printer_video.side_effect = RuntimeError("boom")
+            subject = _VideoLifecycleSubject(client)
+            await subject._ensure_stream_enabled()  # must not raise
+            assert subject._stream_enabled is False
+
+        _run(run())
+
+    def test_disable_stream_sends_disable_and_clears_flag(self) -> None:
+        """Disable sends set_printer_video_stream(enable=False)."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            subject = _VideoLifecycleSubject(client)
+            subject._stream_enabled = True
+            await subject._disable_stream()
+            client.set_printer_video_stream.assert_called_once_with(enable=False)
+            assert subject._stream_enabled is False
+
+        _run(run())
+
+    def test_disable_is_noop_when_not_enabled(self) -> None:
+        """No command if the stream was never enabled."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            subject = _VideoLifecycleSubject(client)
+            await subject._disable_stream()
+            client.set_printer_video_stream.assert_not_called()
+
+        _run(run())
+
+    def test_disable_failure_keeps_flag_for_watchdog(self) -> None:
+        """A failed disable keeps the flag set (watchdog retries)."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            client.set_printer_video_stream.side_effect = RuntimeError("busy")
+            subject = _VideoLifecycleSubject(client)
+            subject._stream_enabled = True
+            await subject._disable_stream()
+            assert subject._stream_enabled is True
+
+        _run(run())
+
+    def test_watchdog_tick_disables_idle_stream(self) -> None:
+        """Enabled with no active viewer gets disabled on the next tick."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            subject = _VideoLifecycleSubject(client)
+            subject._stream_enabled = True
+            await subject._idle_watchdog_tick()
+            client.set_printer_video_stream.assert_called_once_with(enable=False)
+            assert subject._stream_enabled is False
+
+        _run(run())
+
+    def test_watchdog_tick_keeps_stream_while_viewers_active(self) -> None:
+        """Active viewers prevent a tabletop disable."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            subject = _VideoLifecycleSubject(client)
+            subject._stream_enabled = True
+            subject._transient_viewers = 1
+            await subject._idle_watchdog_tick()
+            client.set_printer_video_stream.assert_not_called()
+            assert subject._stream_enabled is True
+
+        _run(run())
+
+    def test_watchdog_tick_clears_idle_native_stream(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A staled native stream flag is cleared for the next disable."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            subject = _VideoLifecycleSubject(client)
+            subject._native_stream_active = True
+            subject._last_activity = 1000.0
+            monkeypatch.setattr(camera_module, "NATIVE_STREAM_IDLE_TIMEOUT", 1.0)
+            await subject._idle_watchdog_tick()
+            assert subject._native_stream_active is False
+
+        _run(run())
+
+    def test_cleanup_video_lifecycle(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Removal cancels the watchdog, resets counters, disables the stream."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            subject = _VideoLifecycleSubject(client)
+            subject._stream_enabled = True
+            subject._active_mjpeg_streams = 1
+            subject._transient_viewers = 1
+            subject._native_stream_active = True
+            task = asyncio.create_task(subject._idle_watchdog())
+            monkeypatch.setattr(
+                camera_module, "IDLE_WATCHDOG_INTERVAL", 100
+            )  # avoid extra ticks interfering
+            await subject._cleanup_video_lifecycle()
+            assert subject._idle_watchdog_task is None
+            assert subject._active_mjpeg_streams == 0
+            assert subject._transient_viewers == 0
+            assert subject._native_stream_active is False
+            assert subject._stream_enabled is False
+            client.set_printer_video_stream.assert_called_once_with(enable=False)
+            task.cancel()
+
+        _run(run())
+
+    def test_idle_watchdog_loop_runs_tick(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The long-lived watchdog loop performs at least one tick."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            subject = _VideoLifecycleSubject(client)
+            subject._stream_enabled = True
+            monkeypatch.setattr(camera_module, "IDLE_WATCHDOG_INTERVAL", 0.001)
+            task = asyncio.create_task(subject._idle_watchdog())
+            # Wait for the first tick to land
+            deadline = asyncio.get_event_loop().time() + 2.0
+            while client.set_printer_video_stream.call_count == 0:
+                if asyncio.get_event_loop().time() > deadline:
+                    break
+                await asyncio.sleep(0.01)
+            assert client.set_printer_video_stream.call_count >= 1
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+        _run(run())
+
+
+class TestFdmMjpegCameraVideoLifecycle:
+    """
+    Cover the #399 leak in the FDM cameras.
+
+    FDM cameras enabled the video stream and never disabled it again,
+    so stream sessions leaked until the printer was power-cycled.
+    """
+
+    def test_camera_image_refcounts_video_on_off(self) -> None:
+        """A single still capture enables once and disables on release."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            cam = _fdm_camera(client)
+            with patch.object(
+                MjpegCamera,
+                "async_camera_image",
+                new=AsyncMock(return_value=b"img"),
+            ):
+                await cam.async_camera_image()
+            client.get_printer_video.assert_called_once_with(enable=True)
+            assert cam._mjpeg_url is not None
+            client.set_printer_video_stream.assert_called_once_with(enable=False)
+            assert cam._active_mjpeg_streams == 0
+            assert cam._transient_viewers == 0
+
+        _run(run())
+
+    def test_camera_image_reuses_enabled_stream(self) -> None:
+        """A capture during an active MJPEG stream must not re-enable the stream."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            cam = _fdm_camera(client)
+            cam._active_mjpeg_streams = 1
+            cam._stream_enabled = True
+            with patch.object(
+                MjpegCamera,
+                "async_camera_image",
+                new=AsyncMock(return_value=b"img"),
+            ):
+                await cam.async_camera_image()
+            client.get_printer_video.assert_not_called()
+            client.set_printer_video_stream.assert_not_called()
+            assert cam._active_mjpeg_streams == 1
+
+        _run(run())
+
+    def test_camera_image_disabled_when_managing(self) -> None:
+        """A failed still capture still disables the stream afterwards."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            cam = _fdm_camera(client)
+            with (
+                patch.object(
+                    MjpegCamera,
+                    "async_camera_image",
+                    new=AsyncMock(side_effect=TimeoutError("frame lost")),
+                ),
+                pytest.raises(TimeoutError),
+            ):
+                await cam.async_camera_image()
+            client.set_printer_video_stream.assert_called_once_with(enable=False)
+            assert cam._stream_enabled is False
+
+        _run(run())
+
+    def test_camera_image_not_connected_no_enable(self) -> None:
+        """No command is issued when the client is disconnected."""
+
+        async def run() -> None:
+            client, _ = _make_client(connected=False)
+            cam = _fdm_camera(client)
+            with patch.object(
+                MjpegCamera,
+                "async_camera_image",
+                new=AsyncMock(return_value=b"img"),
+            ):
+                result = await cam.async_camera_image()
+            assert result is None
+            client.get_printer_video.assert_not_called()
+            client.set_printer_video_stream.assert_not_called()
+
+        _run(run())
+
+    def test_camera_image_over_capacity_no_enable(self) -> None:
+        """An over-capacity printer is left untouched."""
+
+        async def run() -> None:
+            client, _ = _make_client(over_capacity=True)
+            cam = _fdm_camera(client)
+            with patch.object(
+                MjpegCamera,
+                "async_camera_image",
+                new=AsyncMock(return_value=b"img"),
+            ):
+                result = await cam.async_camera_image()
+            assert result is None
+            client.get_printer_video.assert_not_called()
+            client.set_printer_video_stream.assert_not_called()
+
+        _run(run())
+
+    def test_camera_image_failed_keeps_state_clean(self) -> None:
+        """A failed enable leaves no residual enabled state on the stream."""
+
+        async def run() -> None:
+            client, video = _make_client()
+            video.status = ElegooVideoStatus.UNKNOWN_ERROR
+            cam = _fdm_camera(client)
+            with patch.object(
+                MjpegCamera,
+                "async_camera_image",
+                new=AsyncMock(return_value=b"img"),
+            ):
+                result = await cam.async_camera_image()
+            assert result is None
+            # No enable command is sent, no disable needed
+            client.get_printer_video.assert_called_once_with(enable=True)
+            client.set_printer_video_stream.assert_not_called()
+            assert cam._stream_enabled is False
+
+        _run(run())
+
+    def test_handle_mjpeg_stream_enables_and_disables(self) -> None:
+        """A live stream viewer refcounts the video stream."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            cam = _fdm_camera(client)
+            response = MagicMock()
+            with patch.object(
+                MjpegCamera,
+                "handle_async_mjpeg_stream",
+                new=AsyncMock(return_value=response),
+            ) as mjpeg_handler:
+                result = await cam.handle_async_mjpeg_stream(REQUEST)
+            mjpeg_handler.assert_awaited_once()
+            assert result is response
+            client.get_printer_video.assert_called_once_with(enable=True)
+            client.set_printer_video_stream.assert_called_once_with(enable=False)
+            assert cam._active_mjpeg_streams == 0
+
+        _run(run())
+
+    def test_handle_mjpeg_stream_over_capacity_returns_503(self) -> None:
+        """An over-capacity stream request is rejected with 503."""
+
+        async def run() -> None:
+            client, _ = _make_client(over_capacity=True)
+            cam = _fdm_camera(client)
+            with patch.object(
+                MjpegCamera,
+                "handle_async_mjpeg_stream",
+                new=AsyncMock(return_value=MagicMock()),
+            ) as mjpeg_handler:
+                result = await cam.handle_async_mjpeg_stream(REQUEST)
+            mjpeg_handler.assert_not_awaited()
+            assert result.status == 503
+            client.get_printer_video.assert_not_called()
+            client.set_printer_video_stream.assert_not_called()
+
+        _run(run())
+
+    def test_handle_mjpeg_stream_keeps_stream_while_viewers(self) -> None:
+        """A second viewer does not re-sync or re-disable the stream."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            cam = _fdm_camera(client)
+            cam._active_mjpeg_streams = 1
+            cam._stream_enabled = True
+            with patch.object(
+                MjpegCamera,
+                "handle_async_mjpeg_stream",
+                new=AsyncMock(return_value=MagicMock()),
+            ):
+                await cam.handle_async_mjpeg_stream(REQUEST)
+            client.get_printer_video.assert_not_called()
+            client.set_printer_video_stream.assert_not_called()
+            assert cam._active_mjpeg_streams == 1
+
+        _run(run())
+
+    def test_stream_source_refcounts_video(self) -> None:
+        """The native stream path enables, tracks, and releases cleanly."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            camera = _fdm_camera(client)
+            result = await camera.stream_source()
+            assert result is not None
+            client.get_printer_video.assert_called_once_with(enable=True)
+            assert camera._native_stream_active is True
+            # An active native viewer blocks the disable; repeated calls
+            # never re-ask the printer for the URL
+            result = await camera.stream_source()
+            client.get_printer_video.assert_called_once_with(enable=True)
+            # After the idle clear drops the flag, the next tick
+            # releases the stream on the printer
+            camera._native_stream_active = False
+            await camera._idle_watchdog_tick()
+            assert camera._stream_enabled is False
+            client.set_printer_video_stream.assert_called_once_with(enable=False)
+
+        _run(run())
+
+    def test_will_remove_from_hass_disables_stream(self) -> None:
+        """Entity removal releases the video stream on the printer."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            cam = _fdm_camera(client)
+            # The full async_added_to_hass path needs a real coordinator;
+            # the mixin starts its watchdog on add, which the cleanup path
+            # cancels — removal can be verified without the added hook.
+            cam._stream_enabled = True
+            await cam.async_will_remove_from_hass()
+            client.set_printer_video_stream.assert_called_once_with(enable=False)
+            assert cam._idle_watchdog_task is None
+
+        _run(run())
+
+
+class TestResinStreamCameraLifecycle:
+    """Regression: the resin camera's stream lifecycle continues to apply."""
+
+    def test_mjpeg_stream_refcounts(self) -> None:
+        """Stream viewers enable and disable the printer video stream."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            cam = _resin_camera(client)
+            with (
+                patch.object(camera_module, "ElegooCameraMjpeg") as cam_mjpeg,
+                patch.object(
+                    camera_module,
+                    "async_aiohttp_proxy_stream",
+                    new=AsyncMock(return_value=MagicMock()),
+                ),
+            ):
+                cam_mjpeg.return_value.open_camera = AsyncMock()
+                cam_mjpeg.return_value.get_reader = AsyncMock(return_value=MagicMock())
+                cam_mjpeg.return_value.close = AsyncMock()
+                await cam.handle_async_mjpeg_stream(REQUEST)
+            cam_mjpeg.return_value.get_reader.assert_awaited_once()
+            client.get_printer_video.assert_called_once_with(enable=True)
+            client.set_printer_video_stream.assert_called_once_with(enable=False)
+            assert cam._active_mjpeg_streams == 0
+            assert len(cam._active_mjpeg_processes) == 0
+
+        _run(run())
+
+    def test_camera_image_refcounts(self) -> None:
+        """A still capture through the camera class reference-management."""
+
+        async def run() -> None:
+            client, video = _make_client()
+            video.video_url = "rtsp://127.0.0.1:8080/stream"
+            cam = _resin_camera(client)
+            with patch.object(
+                camera_module,
+                "async_get_image",
+                new=AsyncMock(return_value=b"img"),
+            ) as image_mock:
+                await cam.async_camera_image()
+            image_mock.assert_awaited_once()
+            client.get_printer_video.assert_called_once_with(enable=True)
+            client.set_printer_video_stream.assert_called_once_with(enable=False)
+
+        _run(run())
+
+    def test_will_remove_closes_processes_and_disables(self) -> None:
+        """Removal closes in-flight MJPEG processes and releases the stream."""
+
+        async def run() -> None:
+            client, _ = _make_client()
+            cam = _resin_camera(client)
+            cam._stream_enabled = True
+            in_flight = MagicMock()
+            in_flight.close = AsyncMock()
+            with patch.object(camera_module, "ElegooCameraMjpeg") as cam_mjpeg:
+                cam_mjpeg.return_value = in_flight
+                cam._active_mjpeg_processes = {in_flight}
+            await cam.async_will_remove_from_hass()
+            in_flight.close.assert_awaited_once()
+            client.set_printer_video_stream.assert_called_once_with(enable=False)
+
+        _run(run())

--- a/custom_components/elegoo_printer/tests/test_video_lifecycle.py
+++ b/custom_components/elegoo_printer/tests/test_video_lifecycle.py
@@ -232,14 +232,19 @@ class TestVideoLifecycleMixin:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A staled native stream flag is cleared for the next disable."""
+        """A stale native stream flag is cleared for the next disable."""
 
         async def run() -> None:
             client, _ = _make_client()
             subject = _VideoLifecycleSubject(client)
+            # Use a zero timeout and a tiny positive last_activity so the
+            # idle check (loop_time - last > 0) holds regardless of the
+            # event loop's clock basis. A real past value is unrepresentable
+            # when the loop's clock is a fresh counter, so we make the
+            # timeout itself zero instead.
+            monkeypatch.setattr(camera_module, "NATIVE_STREAM_IDLE_TIMEOUT", 0)
             subject._native_stream_active = True
-            subject._last_activity = 1000.0
-            monkeypatch.setattr(camera_module, "NATIVE_STREAM_IDLE_TIMEOUT", 1.0)
+            subject._last_activity = 1e-9
             await subject._idle_watchdog_tick()
             assert subject._native_stream_active is False
 


### PR DESCRIPTION
Fixes #399 — FDM cameras (ElegooMjpegCamera) enabled the printer's video stream on every image grab / stream view but never disabled it, so video stream sessions leaked until the printer was power-cycled.

## Root cause

`ElegooMjpegCamera._update_stream_url()` sent `get_printer_video(enable=True)` on **every** `async_camera_image()` / `handle_async_mjpeg_stream()` call, but never sent `set_printer_video_stream(enable=False)`. The resin camera class (`ElegooStreamCamera`) already had a full ref-counted lifecycle (enable on first viewer, disable on last viewer, an idle watchdog that re-attempts failed disables, and cleanup on entity removal) — the FDM camera had none of it.

## What changed

- Extracted that ref-counted lifecycle into a shared `ElegooVideoStreamLifecycle` mixin (enable on first viewer, disable on last viewer, idle watchdog retry on failed disable, cleanup on entity removal), inherited by both camera classes.
- Applied the same lifecycle to the FDM `ElegooMjpegCamera`, so its video is only active while viewers are connected and released when the last one disconnects (over-capacity / disconnected printers are left untouched).
- The resin `ElegooStreamCamera` keeps identical behavior — refactor-preserving, regression-checked in tests.
- New `tests/test_video_lifecycle.py` — 28 tests over the shared lifecycle (ref-counting, enable disable, watchdog tick + long-running loop, stream lifecycle cleanup) and both camera classes (camera image, stream source, 503 semantics, active viewer behavior, entity removal).

## Verification

- `make format` clean
- `make lint` clean
- `make test` — 396 passing

No version bump in this PR (kept out of scope, no `manifest.json` change).
