### PR TITLE
feat(sensors): pin suggested unit of length sensors to millimeters (#397)

### DIFF
--- a/custom_components/elegoo_printer/definitions.py
+++ b/custom_components/elegoo_printer/definitions.py
@@ -877,6 +877,7 @@ PRINTER_STATUS_FDM: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfLength.MILLIMETERS,
+        suggested_unit_of_measurement=UnitOfLength.MILLIMETERS,
         suggested_display_precision=4,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda printer_data: (
@@ -951,6 +952,7 @@ PRINTER_STATUS_FDM: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfLength.MILLIMETERS,
+        suggested_unit_of_measurement=UnitOfLength.MILLIMETERS,
         suggested_display_precision=2,
         value_fn=lambda printer_data: _get_current_coord_value(printer_data, 0),
     ),
@@ -962,6 +964,7 @@ PRINTER_STATUS_FDM: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfLength.MILLIMETERS,
+        suggested_unit_of_measurement=UnitOfLength.MILLIMETERS,
         suggested_display_precision=2,
         value_fn=lambda printer_data: _get_current_coord_value(printer_data, 1),
     ),
@@ -973,6 +976,7 @@ PRINTER_STATUS_FDM: tuple[ElegooPrinterSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfLength.MILLIMETERS,
+        suggested_unit_of_measurement=UnitOfLength.MILLIMETERS,
         suggested_display_precision=2,
         value_fn=lambda printer_data: _get_current_coord_value(printer_data, 2),
     ),
@@ -987,6 +991,7 @@ PRINTER_STATUS_FDM_TOTAL_EXTRUSION: tuple[ElegooPrinterSensorEntityDescription, 
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.TOTAL_INCREASING,
         native_unit_of_measurement=UnitOfLength.MILLIMETERS,
+        suggested_unit_of_measurement=UnitOfLength.MILLIMETERS,
         suggested_display_precision=2,
         value_fn=lambda printer_data: (
             printer_data.status.print_info.total_extrusion
@@ -1007,6 +1012,7 @@ PRINTER_STATUS_FDM_CURRENT_EXTRUSION: tuple[
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfLength.MILLIMETERS,
+        suggested_unit_of_measurement=UnitOfLength.MILLIMETERS,
         suggested_display_precision=2,
         value_fn=lambda printer_data: (
             printer_data.status.print_info.current_extrusion
@@ -1190,6 +1196,7 @@ PRINTER_STATUS_GCODE_PROXY_FILAMENT: tuple[
             icon="mdi:ruler",
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement=UnitOfLength.MILLIMETERS,
+            suggested_unit_of_measurement=UnitOfLength.MILLIMETERS,
             suggested_display_precision=2,
             value_fn=(lambda pd, _i=i: _get_slot_mm(pd, _i)),
         )

--- a/custom_components/elegoo_printer/tests/test_sensor_units.py
+++ b/custom_components/elegoo_printer/tests/test_sensor_units.py
@@ -1,0 +1,80 @@
+"""
+Tests for sensor unit pinning (issue #397).
+
+Distance-class sensors (current/total extrusion, xy/z position, z offset)
+and the G-code proxy length sensors must pin their display unit to
+millimeters via `suggested_unit_of_measurement`, so HA does not
+convert `state` to the user's unit-system unit (e.g. inches for
+US custom users) — important for consumers like Spoolman expecting mm.
+"""
+
+from homeassistant.const import UnitOfLength
+
+from custom_components.elegoo_printer.definitions import (
+    PRINTER_STATUS_FDM,
+    PRINTER_STATUS_FDM_CURRENT_EXTRUSION,
+    PRINTER_STATUS_FDM_TOTAL_EXTRUSION,
+    PRINTER_STATUS_GCODE_PROXY_FILAMENT,
+)
+
+# key -> expected: must pin suggested unit to mm (+ native mm)
+PINNED_MILLIMETER_KEYS = [
+    "total_extrusion",
+    "current_extrusion",
+    "z_offset",
+    "current_x",
+    "current_y",
+    "current_z",
+    "a1_length_millimeters",
+    "a2_length_millimeters",
+    "a3_length_millimeters",
+    "a4_length_millimeters",
+]
+
+ALL_TUPLES = (
+    PRINTER_STATUS_FDM,
+    PRINTER_STATUS_FDM_TOTAL_EXTRUSION,
+    PRINTER_STATUS_FDM_CURRENT_EXTRUSION,
+    PRINTER_STATUS_GCODE_PROXY_FILAMENT,
+)
+
+
+def _descriptions_by_key() -> dict:
+    """Flatten the relevant definition tuples into {key: description}."""
+    out = {}
+    for items in ALL_TUPLES:
+        for description in items:
+            out[description.key] = description
+    return out
+
+
+class TestSensorUnitPinning:
+    """Distance-class sensors pin the suggested display unit to mm."""
+
+    def test_expected_sensor_keys_present(self) -> None:
+        """The targeted keys all exist in the relevant definition tuples."""
+        by_key = _descriptions_by_key()
+        missing = [k for k in PINNED_MILLIMETER_KEYS if k not in by_key]
+        assert not missing, f"keys missing from definitions: {missing}"
+
+    def test_distance_sensors_pin_mm(self) -> None:
+        """
+        Distance and length sensors pin their display unit to mm.
+
+        They have a matching native unit of mm — so
+        `native == display == mm`, and HA's state stays in
+        millimeters (no conversion to the user's unit system).
+        """
+        by_key = _descriptions_by_key()
+        for key in PINNED_MILLIMETER_KEYS:
+            description = by_key[key]
+            assert (
+                description.suggested_unit_of_measurement == UnitOfLength.MILLIMETERS
+            ), (
+                f"{key} should pin suggested_unit_of_measurement to mm "
+                f"(got {description.suggested_unit_of_measurement})"
+            )
+            assert description.native_unit_of_measurement == UnitOfLength.MILLIMETERS, (
+                f"{key} native unit is "
+                f"{description.native_unit_of_measurement}, expected mm"
+            )


### PR DESCRIPTION
Fixes #397 — Spoolman (OpenCentauri live updating) receives filament values in wrong units for users on non-metric unit systems.

## Root cause (verified in HA 2025.4.0 core source)

`SensorEntity.state` (homeassistant/components/sensor/__init__.py:662) converts the raw value **only** when `native_unit_of_measurement != unit_of_measurement` **and** the `device_class` is a convertible one (`distance`, `temperature`, …). The display unit is resolved with priority: **user override → suggested unit (pinned at first registration) → unit system conversion → native**.

Our length sensors (`current_extrusion`, `total_extrusion`, `current_x/y/z`, `z_offset`) declare `device_class=distance` + `native_unit=mm` but had **no suggested unit**, so HA pinned their display unit to the unit-system conversion at first registration (e.g. `mm → inches` for US-customary users). Consumers reading `state` — like Spoolman via the OpenCentauri live update — then received inches instead of mm.

## What changed

- Added `suggested_unit_of_measurement=UnitOfLength.MILLIMETERS` to all 10 affected sensor definitions:
  - `current_extrusion`, `total_extrusion` (what Spoolman's live update reads)
  - `current_x` / `current_y` / `current_z`, `z_offset` (positional)
  - `a1-a4_length_millimeters` (G-code proxy filament sensors)
- With `native == display == mm`, the conversion gate never fires → **`state` stays in millimeters regardless of the user's unit system.**
- New `tests/test_sensor_units.py` asserting the pinning for every affected sensor.

## Caveats

- **Already-registered sensors** keep the unit pinned from first registration (HA registry stability behavior) — the fix applies cleanly to new installs/resets; existing pins can be changed per-sensor in entity settings.
- Users can still override the unit per-sensor (user override has priority over suggested).

## Verification

- `make format` clean
- `make lint` clean
- `make test` — 398 passing

No version bump in this PR (no `manifest.json` change).
