### PR TITLE
Small bug fixes: typos, attribute double peel, etc.

### DIFF
--- a/custom_components/elegoo_printer/mqtt/client.py
+++ b/custom_components/elegoo_printer/mqtt/client.py
@@ -543,6 +543,8 @@ class ElegooMQTTClient(SdcpPrinterClient):
                     self.logger.exception("Failed to decode MQTT message")
                 except (json.JSONDecodeError, KeyError, ValueError):
                     self.logger.exception("Error processing MQTT message")
+                except Exception:
+                    self.logger.exception("Failed to process MQTT message")
         except asyncio.CancelledError:
             self.logger.debug("MQTT listener cancelled.")
         except (asyncio.TimeoutError, OSError, aiomqtt.MqttError):

--- a/custom_components/elegoo_printer/mqtt/client.py
+++ b/custom_components/elegoo_printer/mqtt/client.py
@@ -660,7 +660,6 @@ class ElegooMQTTClient(SdcpPrinterClient):
             data_content = data["Data"]
             self.logger.debug("Data content keys: %s", list(data_content.keys()))
             if "Attributes" in data_content:
-                attributes_data = data_content["Attributes"]
                 self.logger.debug("Extracted attributes data successfully")
             else:
                 self.logger.warning(
@@ -668,16 +667,14 @@ class ElegooMQTTClient(SdcpPrinterClient):
                     list(data_content.keys()),
                 )
                 return
+            self._apply_attributes(data_content)
         elif "Attributes" in data:
-            # Fallback for WebSocket format
             self.logger.debug("Using WebSocket fallback format")
-            attributes_data = data["Attributes"]
+            self._apply_attributes(data)
         else:
             keys = list(data.keys())
             self.logger.warning("Unknown attributes message format: %s", keys)
             return
-
-        self._apply_attributes(attributes_data)
 
     def _set_response_event_sync(self, request_id: str) -> None:
         """Set the event for a given request ID (synchronous wrapper)."""

--- a/custom_components/elegoo_printer/sdcp/tests/test_transport_base.py
+++ b/custom_components/elegoo_printer/sdcp/tests/test_transport_base.py
@@ -180,6 +180,17 @@ async def test_listen_not_implemented_in_base() -> None:
         await bare._listen()
 
 
+async def test_get_printer_task_detail_not_implemented_in_base() -> None:
+    """The base get_printer_task_detail must raise NotImplementedError."""
+
+    class _Bare(SdcpPrinterClient):
+        """A bare base instance (no transport overrides)."""
+
+    bare = _Bare(None, Printer())
+    with pytest.raises(NotImplementedError):
+        await bare.get_printer_task_detail(["test_id"])
+
+
 async def test_request_topic_base_starts_without_leading_slash() -> None:
     """The base request topic keeps the wire prefix as-is (ws shape)."""
     client = _make_client(logger=None)

--- a/custom_components/elegoo_printer/sdcp/transport/base.py
+++ b/custom_components/elegoo_printer/sdcp/transport/base.py
@@ -60,8 +60,8 @@ if TYPE_CHECKING:
     from custom_components.elegoo_printer.sdcp.types import (
         SDCPElegooVideoFrame,
         SDCPStatusMessage,
-        SDPPrintHistoryDetailFrame,
-        SDPPrintHistoryMessage,
+        SDCPPrintHistoryDetailFrame,
+        SDCPPrintHistoryMessage,
     )
 
 __all__ = ["SdcpPrinterClient"]
@@ -273,7 +273,7 @@ class SdcpPrinterClient:
             case "elegoo_video":
                 self._print_video_handler(data)
 
-    def _print_history_handler(self, data_data: SDPPrintHistoryMessage) -> None:
+    def _print_history_handler(self, data_data: SDCPPrintHistoryMessage) -> None:
         """
         Parse and update the printer's print history cache from the data.
 
@@ -287,7 +287,7 @@ class SdcpPrinterClient:
                     self.printer_data.print_history[task_id] = None
 
     def _print_history_detail_handler(
-        self, data_data: SDPPrintHistoryDetailFrame
+        self, data_data: SDCPPrintHistoryDetailFrame
     ) -> None:
         """
         Parse and update the printer's print history details from the data.

--- a/custom_components/elegoo_printer/sdcp/transport/base.py
+++ b/custom_components/elegoo_printer/sdcp/transport/base.py
@@ -180,6 +180,13 @@ class SdcpPrinterClient:
         msg = "publish_frame must be implemented by the transport"
         raise NotImplementedError(msg)
 
+    async def get_printer_task_detail(
+        self, id_list: list[str]
+    ) -> PrintHistoryDetail | None:
+        """Fetch task detail by ID (overridden per transport)."""
+        msg = "get_printer_task_detail must be implemented by the transport"
+        raise NotImplementedError(msg)
+
     async def _send_printer_cmd(
         self, cmd: int, data: dict[str, Any] | None = None
     ) -> None:

--- a/custom_components/elegoo_printer/sdcp/types.py
+++ b/custom_components/elegoo_printer/sdcp/types.py
@@ -119,7 +119,7 @@ type SDCPStatusMessage = SDCPStatusWrapper | SDCPStatusPayload
 decodes the inner payload."""
 
 
-class SDPPrintHistoryMessage(TypedDict, total=False):
+class SDCPPrintHistoryMessage(TypedDict, total=False):
     """A `print_history` frame (key -> sparse task-summary dicts)."""
 
     PrintHistory: dict[str, Any]
@@ -128,7 +128,7 @@ class SDPPrintHistoryMessage(TypedDict, total=False):
     HistoryData: list[Any]
 
 
-class SDPPrintHistoryDetailFrame(TypedDict, total=False):
+class SDCPPrintHistoryDetailFrame(TypedDict, total=False):
     """A `PrintHistoryDetail` frame (sparse; nested shape stays `Any`)."""
 
     PrintInfo: dict[str, Any]

--- a/custom_components/elegoo_printer/tests/test_mqtt_client.py
+++ b/custom_components/elegoo_printer/tests/test_mqtt_client.py
@@ -309,15 +309,7 @@ async def test_status_push_updates_printer_data(
 async def test_attributes_push_updates_printer_data(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """
-    An attributes push frame re-assigns printer_data.attributes.
-
-    Pins CURRENT (buggy) behavior: the MQTT handler unwraps
-    ``data["Data"]["Attributes"]`` but ``PrinterAttributes.from_json``
-    expects the wrapper shape ``{"Attributes": ...}`` (the WebSocket
-    handler passes the whole message, so only the MQTT transport is
-    affected). The flat payload is dropped, leaving empty attribute values.
-    """
+    """An attributes push frame re-assigns printer_data.attributes."""
     _speed_up_wait_for(monkeypatch)
     fake = FakeAiomqttClient()
     client = _make_client(fake)
@@ -339,9 +331,8 @@ async def test_attributes_push_updates_printer_data(
     await _wait_until(lambda: client.printer_data.attributes is not default_attributes)
     assert await client.get_printer_attributes() is client.printer_data
     assert isinstance(client.printer_data.attributes, PrinterAttributes)
-    # Pin the wrapper-mismatch behavior (attribute values are dropped).
-    assert client.printer_data.attributes.firmware_version == ""
-    assert client.printer_data.attributes.machine_name == ""
+    assert client.printer_data.attributes.firmware_version == "V1.2.3"
+    assert client.printer_data.attributes.machine_name == "Saturn 4"
     await _teardown(client, None)
 
 


### PR DESCRIPTION
Fixes a few small things:
- SDCP typos
- General Exception catch
- Stub method on base class
- Attribute getting double peeled when it only needed once.