### PR TITLE
docs(cc2): fix slot_map entry format — key is `t`, not `slot`; ids are 0-based

### DIFF
--- a/docs/CC2_PROTOCOL.md
+++ b/docs/CC2_PROTOCOL.md
@@ -1548,9 +1548,9 @@ Response (from stock firmware testing):
 |-------|------|-------------|
 | `color` | string | Hex color code with `#` prefix |
 | `name` | string | Filament type name (e.g., "PLA", "PETG") |
-| `t` | int | Canvas tray index used for this slot |
+| `t` | int | Extruder index from the slicer, 0-based — the G-code tool index (`T0`, `T1`, …), not a Canvas tray |
 
-For multi-material prints, `color_map` contains one entry per extruder/slot used. The `t` field maps to the Canvas tray index (0-based). The `total_filament_used` field is a single total value — per-extruder weight breakdown is not available via this method (it exists only in the G-code file comments).
+For multi-material prints, `color_map` contains one entry per extruder used. `t` is the slicer's extruder index (0-based); `color` and `name` are the filament as configured in the slicer, not the tray the file was or will be printed from — the tray is chosen at start time via `slot_map` (see [Printing with Canvas](#printing-with-canvas)). The `total_filament_used` field is a single total value — per-extruder weight breakdown is not available via this method (it exists only in the G-code file comments).
 
 ### Method 1057 - SET_PRINTER_DOWNLOAD_FILE
 
@@ -1827,7 +1827,7 @@ serialised in `src/lan/adapters/elegoo_fdm_cc2/elegoo_fdm_cc2_message_adapter.cp
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `t` | int | Tool index in the G-code (`T0`, `T1`, …), 0-based — the same value as `color_map[].t` in the file list (method 1044) |
+| `t` | int | Tool index in the G-code (`T0`, `T1`, …), 0-based — the same value as `color_map[].t` in the file list / file detail (methods 1044, 1046) |
 | `canvas_id` | int | Which Canvas unit, 0-based |
 | `tray_id` | int | Which tray of that unit, 0-based (0–3 on a four-tray Canvas) |
 

--- a/docs/CC2_PROTOCOL.md
+++ b/docs/CC2_PROTOCOL.md
@@ -1804,7 +1804,9 @@ The Canvas is Elegoo's Automatic Material System (similar to Bambu Lab AMS).
 
 ### Printing with Canvas
 
-When starting a print with Canvas, include slot mapping:
+When starting a print with Canvas, `config.slot_map` maps each tool index of the G-code to a
+physical tray. Entry format from elegoo-link (`SlotMapItem` in `include/types/printer.h`,
+serialised in `src/lan/adapters/elegoo_fdm_cc2/elegoo_fdm_cc2_message_adapter.cpp`):
 
 ```json
 {
@@ -1815,13 +1817,22 @@ When starting a print with Canvas, include slot mapping:
     "filename": "multicolor.gcode",
     "config": {
       "slot_map": [
-        {"slot": 1, "canvas_id": 1, "tray_id": 1},
-        {"slot": 2, "canvas_id": 1, "tray_id": 2}
+        {"t": 0, "canvas_id": 0, "tray_id": 2},
+        {"t": 1, "canvas_id": 0, "tray_id": 0}
       ]
     }
   }
 }
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `t` | int | Tool index in the G-code (`T0`, `T1`, …), 0-based — the same value as `color_map[].t` in the file list (method 1044) |
+| `canvas_id` | int | Which Canvas unit, 0-based |
+| `tray_id` | int | Which tray of that unit, 0-based (0–3 on a four-tray Canvas) |
+
+An empty `slot_map` leaves the tray choice to the printer. The other `config` fields are
+described under [Start Print](#start-print).
 
 ---
 
@@ -1930,7 +1941,7 @@ This section documents the complete sequence of events when ElegooSlicer sends a
 | `printer_check` | bool | Run pre-print checks |
 | `print_layout` | string | Layout option (model-specific) |
 | `bedlevel_force` | bool | Force bed leveling before print |
-| `slot_map` | array | Canvas/AMS filament mapping |
+| `slot_map` | array | Canvas/AMS filament mapping, see [Printing with Canvas](#printing-with-canvas) |
 
 ### Pause Print
 


### PR DESCRIPTION
The "Printing with Canvas" example in `docs/CC2_PROTOCOL.md` used `slot` as the entry key and 1-based ids. Elegoo's own elegoo-link SDK writes `t`, `canvas_id` and `tray_id`, all 0-based:

- `include/types/printer.h` — `struct SlotMapItem { int t; int canvasId; int trayId; }`, with `t` commented as the index of the G-code `T` command
- `src/lan/adapters/elegoo_fdm_cc2/elegoo_fdm_cc2_message_adapter.cpp` — `itemJson["t"] = item.t; ... ["canvas_id"] ... ["tray_id"]`

`t` is the same value as `color_map[].t` in the 1044 file list. The example now keeps `t` and `tray_id` visibly different so the two are not read as the same number, and the `slot_map` row of the config table links to the section.

**Verified** on a Centauri Carbon 2 Combo, firmware 02.01.00.00, single-tool G-codes, payloads taken from the sending script / HA trace:

- `config` as in the "Start Print" section with `slot_map: [{"t": 0, "canvas_id": 0, "tray_id": 3}]` → printed from tray 4; the previous print had used tray 2.
- `config: {"slot_map": [{"tray_id": 0}]}` and nothing else → `error_code 0`, Canvas loaded tray 1 (`active_tray_id: 0`), printed; the previous print had used tray 4. So `t` and `canvas_id` default, and the other `config` fields may be omitted.
- No `config` at all → started, printer used the last active tray. `config: {"slot_map": []}` → `error_code 0`, started, printer again used the last active tray. (One observation each.)

**Not verified:** multi-tool mappings (`t` ≥ 1) and `canvas_id` other than 0.

Second commit, after review: the file-list `color_map[].t` was documented as a Canvas tray index; the same printer's file list shows it is the slicer's extruder index (details in the commit message and the review thread).

Docs only, no code changes.
