### PR TITLE
feat(cc2): add start_print service for the Centauri Carbon 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Canvas (AMS) support for the Centauri Carbon (CC1): per-slot filament sensors, active tray, and filament colors, matching the existing CC2 support. Canvas presence is auto-detected during setup and stored per printer.
 - Per-slot filament usage sensors for the CC1 via the gcode capture proxy. The proxy URL is now configured in the WebSocket printer options, and works with or without a Canvas installed.
 - New FDM print states reported verbatim from the printer — auto leveling, resonance testing, preheating/homing/leveling completed, auto feeding, and filament unload states — with an explicit `unrecognized` fallback so unknown codes can no longer freeze the status sensor.
+- New `start_print` service for the Centauri Carbon 2: start a G-code file already in the printer's storage from the Developer Tools UI or an automation, optionally on a chosen Canvas tray, with auto bed leveling on by default as in the slicer; the response reports whether the printer accepted the job.
 - New `update_ip` service: change a printer's IP address from the Developer Tools UI or an automation (e.g. an external IP-detection script) without deleting and re-adding the integration; the config entry reloads with the new address and the service reports whether the printer is reachable at it.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ data:
 ```
 
 - The response says whether the printer accepted the job: `error_code` 1009 means it is busy.
-- `tray` is validated by Home Assistant, **not by the printer** - an out-of-range tray is acknowledged with `error_code` 0 and silently printed from tray 0. Only G-code tool 0 is mapped; multi-material files keep the slicer's mapping.
+- `tray` is validated by Home Assistant, **not by the printer** - an out-of-range tray is acknowledged with `error_code` 0 and silently printed from tray 0. Only G-code tool 0 is mapped; this service does not preserve a complete multi-tool mapping.
 - `bed_leveling` maps to the protocol's `printer_check`, which ElegooSlicer sends on every job - so it defaults to on. With `false` the key is left out and the printer levels only when it decides to on its own (observed after a bed-temperature change).
 - Not available for the first-generation Centauri Carbon or resin printers, where the equivalent SDCP command crashed the printer (#297).
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,23 @@ When a printer's IP changes (e.g. via DHCP), there is no need to delete and re-a
 - On a **still-connected (LOADED) entry** the reload effectively runs twice — once triggered by the data change and once explicitly. Home Assistant serializes both, but that means a **second full teardown/reconnect** of the printer connection. On an entry whose printer is unreachable at the old IP (the common DHCP-move case) it is exactly **one reload**.
 - If the printer is **unreachable at the new address**, the entry ends in `SETUP_ERROR` / `SETUP_RETRY` and the service reports failure in its response. **Check the response (or the logs) before assuming success.**
 
+### `start_print` (Centauri Carbon 2 only)
+Starts a G-code file that is **already in the printer's local storage** - the "print this again" the Elegoo app offers, which is lost in LAN Only mode. Uploading a file is not part of this service; the slicer does that.
+
+```yaml
+action: elegoo_printer.start_print
+data:
+  entry_id: <config entry UUID>
+  filename: "benchy.gcode"   # exact name from the printer's file list
+  tray: 2                    # optional, Canvas tray 0-3 (A1-A4) for G-code tool 0
+  bed_leveling: true         # optional, default true: auto bed leveling first (~3 min), as the slicer does
+```
+
+- The response says whether the printer accepted the job: `error_code` 1009 means it is busy.
+- `tray` is validated by Home Assistant, **not by the printer** - an out-of-range tray is acknowledged with `error_code` 0 and silently printed from tray 0. Only G-code tool 0 is mapped; multi-material files keep the slicer's mapping.
+- `bed_leveling` maps to the protocol's `printer_check`, which ElegooSlicer sends on every job - so it defaults to on. With `false` the key is left out and the printer levels only when it decides to on its own (observed after a bed-temperature change).
+- Not available for the first-generation Centauri Carbon or resin printers, where the equivalent SDCP command crashed the printer (#297).
+
 ---
 
 ## 📊 Entities

--- a/custom_components/elegoo_printer/__init__.py
+++ b/custom_components/elegoo_printer/__init__.py
@@ -30,6 +30,8 @@ from homeassistant.loader import async_get_loaded_integration
 from custom_components.elegoo_printer.websocket.client import ElegooPrinterClient
 
 from .api import ElegooPrinterApiClient
+from .cc2.client import ElegooCC2Client
+from .cc2.const import CC2_ERROR_PRINTER_BUSY
 from .const import (
     CONF_PROXY_ENABLED,
     CONFIG_VERSION_1,
@@ -42,6 +44,10 @@ from .const import (
 )
 from .coordinator import ElegooDataUpdateCoordinator
 from .data import ElegooPrinterData
+from .sdcp.exceptions import (
+    ElegooPrinterConnectionError,
+    ElegooPrinterNotConnectedError,
+)
 from .websocket.server import ElegooPrinterServer
 
 if TYPE_CHECKING:
@@ -149,6 +155,86 @@ async def _async_update_ip(hass: HomeAssistant, call: ServiceCall) -> dict:
     return {"success": True, "message": f"IP updated to {new_ip} and entry reloaded"}
 
 
+SERVICE_START_PRINT = "start_print"
+
+# `tray` is validated here because the printer does not: an out-of-range
+# tray_id is acknowledged with error_code 0 and silently printed from tray 0
+# (measured on a CC2, firmware 02.01.00.00). Four trays is what the Canvas has.
+SERVICE_START_PRINT_SCHEMA = vol.Schema(
+    {
+        vol.Required("entry_id"): str,
+        vol.Required("filename"): vol.Length(min=1),
+        vol.Optional("tray"): vol.All(vol.Coerce(int), vol.Range(min=0, max=3)),
+        # default matches ElegooSlicer, which sends printer_check: true on
+        # every job; users who want a faster reprint pass false.
+        vol.Optional("bed_leveling", default=True): bool,
+    }
+)
+
+
+async def _async_start_print(hass: HomeAssistant, call: ServiceCall) -> dict:
+    """
+    Start a file that is already in a Centauri Carbon 2's local storage.
+
+    CC2 only - the SDCP transports are deliberately not wired up, since
+    CMD_START_PRINT crashed the first-gen Centauri Carbon (#297). Accepts
+    ``entry_id``, ``filename``, optional ``tray`` (0-based Canvas tray for
+    G-code tool 0) and ``bed_leveling`` (default on, as the slicer does), and returns a
+    definitive ``{success, message|error}`` result (supports_response=optional).
+    """
+    entry_id = call.data["entry_id"]
+    entry = hass.config_entries.async_get_entry(entry_id)
+    # Same guard as update_ip: the selector limits the UI, not automations.
+    if entry is None or entry.domain != DOMAIN:
+        return {
+            "success": False,
+            "error": f"Config entry {entry_id} not found for {DOMAIN}",
+        }
+    if entry.state is not ConfigEntryState.LOADED:
+        return {
+            "success": False,
+            "error": f"Config entry {entry_id} is not loaded (state: {entry.state})",
+        }
+
+    client = entry.runtime_data.api.client
+    if not isinstance(client, ElegooCC2Client):
+        return {
+            "success": False,
+            "error": "start_print is only available for Centauri Carbon 2 printers",
+        }
+
+    filename = call.data["filename"]
+    tray = call.data.get("tray")
+    bed_leveling = call.data.get("bed_leveling", True)
+    try:
+        code = await client.print_start(
+            filename, tray_id=tray, bed_leveling=bed_leveling
+        )
+    except (ElegooPrinterNotConnectedError, ElegooPrinterConnectionError) as err:
+        LOGGER.warning("start_print failed for entry %s: %r", entry_id, err)
+        return {
+            "success": False,
+            "error": f"Printer not reachable ({err.__class__.__name__})",
+        }
+
+    if code != 0:
+        reason = (
+            "Printer is busy"
+            if code == CC2_ERROR_PRINTER_BUSY
+            else "Printer refused the job"
+        )
+        return {"success": False, "error": f"{reason} (error_code {code})"}
+
+    LOGGER.info(
+        "Print started on entry %s: %s (tray=%s, bed_leveling=%s)",
+        entry_id,
+        filename,
+        tray,
+        bed_leveling,
+    )
+    return {"success": True, "message": f"Print started: {filename}"}
+
+
 # https://developers.home-assistant.io/docs/creating_integration_file_structure/#defining-services
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:  # noqa: ARG001
     """Set up the Elegoo Printer component."""
@@ -159,6 +245,13 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:  # noqa: ARG00
         SERVICE_UPDATE_IP,
         _async_update_ip,
         schema=SERVICE_UPDATE_IP_SCHEMA,
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_START_PRINT,
+        _async_start_print,
+        schema=SERVICE_START_PRINT_SCHEMA,
         supports_response=SupportsResponse.OPTIONAL,
     )
     return True

--- a/custom_components/elegoo_printer/__init__.py
+++ b/custom_components/elegoo_printer/__init__.py
@@ -8,6 +8,7 @@ https://github.com/danielcherubini/elegoo-homeassistant
 from __future__ import annotations
 
 import asyncio
+from functools import partial
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 
@@ -240,17 +241,21 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:  # noqa: ARG00
     """Set up the Elegoo Printer component."""
     # `config` is part of the HA async_setup contract (the manifest-level
     # service registration is unconditional); ARG001 noqa is intentional.
+    #
+    # HA invokes a service handler with the ServiceCall only, so the
+    # (hass, call) handlers are bound with partial. Registering them bare
+    # raises "missing 1 required positional argument: 'call'" on every call.
     hass.services.async_register(
         DOMAIN,
         SERVICE_UPDATE_IP,
-        _async_update_ip,
+        partial(_async_update_ip, hass),
         schema=SERVICE_UPDATE_IP_SCHEMA,
         supports_response=SupportsResponse.OPTIONAL,
     )
     hass.services.async_register(
         DOMAIN,
         SERVICE_START_PRINT,
-        _async_start_print,
+        partial(_async_start_print, hass),
         schema=SERVICE_START_PRINT_SCHEMA,
         supports_response=SupportsResponse.OPTIONAL,
     )

--- a/custom_components/elegoo_printer/cc2/client.py
+++ b/custom_components/elegoo_printer/cc2/client.py
@@ -51,6 +51,7 @@ from .const import (
     CC2_CMD_SET_PRINT_SPEED,
     CC2_CMD_SET_TEMPERATURE,
     CC2_CMD_SET_VIDEO_STREAM,
+    CC2_CMD_START_PRINT,
     CC2_CMD_STOP_PRINT,
     CC2_COMMAND_TIMEOUT,
     CC2_DISCONNECT_DELAY,
@@ -1430,6 +1431,49 @@ class ElegooCC2Client:
     async def print_resume(self) -> None:
         """Resume/continue the current print."""
         await self._send_command(CC2_CMD_RESUME_PRINT)
+
+    async def print_start(
+        self,
+        filename: str,
+        *,
+        tray_id: int | None = None,
+        bed_leveling: bool = True,
+    ) -> int:
+        """
+        Start printing a file that is already in the printer's local storage.
+
+        Sends method 1020 with a ``config`` that carries only what is needed:
+        ``slot_map`` maps G-code tool 0 to ``tray_id`` when one is given (an
+        empty list lets the printer pick the tray), and ``printer_check: true``
+        - what ElegooSlicer sends on every job - forces auto bed leveling.
+        With ``bed_leveling=False`` the key is omitted rather than sent as
+        false: omitted is the measured shape, and the printer then levels only
+        when it decides to on its own. The other ``config`` fields the slicer
+        sends are not required.
+
+        Measured on a Centauri Carbon 2 (firmware 02.01.00.00): a ``slot_map``
+        entry must carry ``t``, ``canvas_id`` and ``tray_id`` together. A
+        partial entry, or an out-of-range ``tray_id``, is acknowledged with
+        ``error_code`` 0 and the printer silently prints from tray 0 - so the
+        response cannot be used to validate the mapping. Only tool 0 is mapped.
+
+        Returns:
+            The ``error_code`` from the printer's response
+            (0 = started, 1009 = printer busy).
+
+        """
+        slot_map: list[dict[str, int]] = []
+        if tray_id is not None:
+            slot_map.append({"t": 0, "canvas_id": 0, "tray_id": tray_id})
+        config: dict[str, Any] = {"slot_map": slot_map}
+        if bed_leveling:
+            config["printer_check"] = True
+        response = await self._send_command(
+            CC2_CMD_START_PRINT,
+            {"storage_media": "local", "filename": filename, "config": config},
+        )
+        result = (response or {}).get("result") or {}
+        return int(result.get("error_code", 0))
 
     async def set_fan_speed(self, percentage: int, fan: ElegooFan) -> None:
         """Set the speed of a fan."""

--- a/custom_components/elegoo_printer/cc2/client.py
+++ b/custom_components/elegoo_printer/cc2/client.py
@@ -1461,6 +1461,13 @@ class ElegooCC2Client:
             The ``error_code`` from the printer's response
             (0 = started, 1009 = printer busy).
 
+        Raises:
+            ElegooPrinterConnectionError: if the printer did not acknowledge
+                the command - ``_send_command`` returns ``None`` when the
+                client disconnects while waiting, and a response without a
+                result or error code is treated the same way, so a print is
+                never reported as started without the printer saying so.
+
         """
         slot_map: list[dict[str, int]] = []
         if tray_id is not None:
@@ -1472,8 +1479,11 @@ class ElegooCC2Client:
             CC2_CMD_START_PRINT,
             {"storage_media": "local", "filename": filename, "config": config},
         )
-        result = (response or {}).get("result") or {}
-        return int(result.get("error_code", 0))
+        result = (response or {}).get("result")
+        if not isinstance(result, dict) or "error_code" not in result:
+            msg = "No acknowledgement from the printer for start print"
+            raise ElegooPrinterConnectionError(msg)
+        return int(result["error_code"])
 
     async def set_fan_speed(self, percentage: int, fan: ElegooFan) -> None:
         """Set the speed of a fan."""

--- a/custom_components/elegoo_printer/cc2/tests/test_start_print.py
+++ b/custom_components/elegoo_printer/cc2/tests/test_start_print.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from custom_components.elegoo_printer.cc2.client import ElegooCC2Client
 from custom_components.elegoo_printer.cc2.const import (
     CC2_CMD_START_PRINT,
     CC2_ERROR_PRINTER_BUSY,
+)
+from custom_components.elegoo_printer.sdcp.exceptions import (
+    ElegooPrinterConnectionError,
 )
 from custom_components.elegoo_printer.sdcp.models.enums import PrinterType
 from custom_components.elegoo_printer.sdcp.models.printer import Printer
@@ -86,3 +91,23 @@ def test_start_returns_printer_error_code() -> None:  # noqa: D103
     ):
         code = asyncio.run(client.print_start("benchy.gcode"))
     assert code == CC2_ERROR_PRINTER_BUSY
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,  # client disconnected while waiting: _send_command returns None
+        {"id": 1, "method": CC2_CMD_START_PRINT},  # no result at all
+        {"id": 1, "method": CC2_CMD_START_PRINT, "result": {}},  # no error_code
+    ],
+)
+def test_start_without_acknowledgement_raises(response: dict | None) -> None:  # noqa: D103
+    # A missing acknowledgement must not be reported as error_code 0 ("started").
+    client = _client()
+    with (
+        patch.object(
+            client, "_send_command", new_callable=AsyncMock, return_value=response
+        ),
+        pytest.raises(ElegooPrinterConnectionError),
+    ):
+        asyncio.run(client.print_start("benchy.gcode"))

--- a/custom_components/elegoo_printer/cc2/tests/test_start_print.py
+++ b/custom_components/elegoo_printer/cc2/tests/test_start_print.py
@@ -1,0 +1,88 @@
+"""Tests for the CC2 start-print command (method 1020)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from custom_components.elegoo_printer.cc2.client import ElegooCC2Client
+from custom_components.elegoo_printer.cc2.const import (
+    CC2_CMD_START_PRINT,
+    CC2_ERROR_PRINTER_BUSY,
+)
+from custom_components.elegoo_printer.sdcp.models.enums import PrinterType
+from custom_components.elegoo_printer.sdcp.models.printer import Printer
+
+
+def _client() -> ElegooCC2Client:
+    printer = Printer()
+    printer.printer_type = PrinterType.FDM
+    return ElegooCC2Client("192.168.1.1", "TESTSN", printer=printer)
+
+
+def _response(error_code: int) -> dict:
+    return {
+        "id": 1,
+        "method": CC2_CMD_START_PRINT,
+        "result": {"error_code": error_code},
+    }
+
+
+def test_start_default_sends_empty_slot_map_and_printer_check() -> None:  # noqa: D103
+    # Defaults mirror what ElegooSlicer sends: no tray mapping, leveling on.
+    client = _client()
+    with patch.object(
+        client, "_send_command", new_callable=AsyncMock, return_value=_response(0)
+    ) as mock_cmd:
+        code = asyncio.run(client.print_start("benchy.gcode"))
+        mock_cmd.assert_called_once_with(
+            CC2_CMD_START_PRINT,
+            {
+                "storage_media": "local",
+                "filename": "benchy.gcode",
+                "config": {"slot_map": [], "printer_check": True},
+            },
+        )
+    assert code == 0
+
+
+def test_start_with_tray_sends_full_slot_map_entry() -> None:  # noqa: D103
+    # The entry must carry t, canvas_id and tray_id together: a partial entry
+    # is acknowledged but not honoured by the printer (fw 02.01.00.00).
+    client = _client()
+    with patch.object(
+        client, "_send_command", new_callable=AsyncMock, return_value=_response(0)
+    ) as mock_cmd:
+        asyncio.run(client.print_start("benchy.gcode", tray_id=3, bed_leveling=False))
+        mock_cmd.assert_called_once_with(
+            CC2_CMD_START_PRINT,
+            {
+                "storage_media": "local",
+                "filename": "benchy.gcode",
+                "config": {"slot_map": [{"t": 0, "canvas_id": 0, "tray_id": 3}]},
+            },
+        )
+
+
+def test_start_without_bed_leveling_omits_printer_check() -> None:  # noqa: D103
+    # Omitted, not false: omitted is the shape that was measured on the printer.
+    client = _client()
+    with patch.object(
+        client, "_send_command", new_callable=AsyncMock, return_value=_response(0)
+    ) as mock_cmd:
+        asyncio.run(client.print_start("benchy.gcode", bed_leveling=False))
+        params = mock_cmd.call_args.args[1]
+        assert params["config"] == {"slot_map": []}
+        assert "printer_check" not in params["config"]
+
+
+def test_start_returns_printer_error_code() -> None:  # noqa: D103
+    client = _client()
+    with patch.object(
+        client,
+        "_send_command",
+        new_callable=AsyncMock,
+        return_value=_response(CC2_ERROR_PRINTER_BUSY),
+    ):
+        code = asyncio.run(client.print_start("benchy.gcode"))
+    assert code == CC2_ERROR_PRINTER_BUSY

--- a/custom_components/elegoo_printer/services.yaml
+++ b/custom_components/elegoo_printer/services.yaml
@@ -16,3 +16,46 @@ update_ip:
       required: true
       selector:
         text:
+
+start_print:
+  name: Start Print
+  description: >-
+    Start a G-code file that is already in the printer's local storage.
+    Centauri Carbon 2 only. The response reports whether the printer accepted
+    the job (error_code 1009 means it is busy).
+  fields:
+    entry_id:
+      name: Config Entry
+      description: The Centauri Carbon 2 to print on.
+      required: true
+      selector:
+        config_entry:
+          integration: elegoo_printer
+    filename:
+      name: File name
+      description: "Exact file name on the printer, as shown in its file list."
+      example: "benchy.gcode"
+      required: true
+      selector:
+        text:
+    tray:
+      name: Canvas tray
+      description: >-
+        Tray to print from, 0-3 (A1-A4). Leave empty to let the printer choose.
+        Maps G-code tool 0 only.
+      required: false
+      selector:
+        number:
+          min: 0
+          max: 3
+          mode: box
+    bed_leveling:
+      name: Bed leveling
+      description: >-
+        Run auto bed leveling before the print, as the slicer does (about three
+        minutes). Switch off for a faster reprint; the printer may still level
+        on its own, for example after a bed-temperature change.
+      required: false
+      default: true
+      selector:
+        boolean:

--- a/custom_components/elegoo_printer/tests/test_services.py
+++ b/custom_components/elegoo_printer/tests/test_services.py
@@ -97,6 +97,25 @@ class TestUpdateIpService:
 
         asyncio.run(_run())
 
+    def test_registered_update_ip_handler_takes_the_call_alone(self) -> None:
+        # HA calls a service handler with the ServiceCall only. A bare
+        # (hass, call) function registered directly raises TypeError on every
+        # call; this exercises the callable HA would actually invoke.
+        async def _run() -> None:
+            hass = MagicMock()
+            hass.config_entries.async_get_entry.return_value = None
+            await async_setup(hass, {})
+            handler = hass.services.async_register.call_args_list[0].args[2]
+
+            call = MagicMock()
+            call.data = {"entry_id": "ghost-404", "ip_address": "198.51.100.7"}
+            result = await handler(call)
+
+            assert result["success"] is False
+            assert "ghost-404" in _error_message(result)
+
+        asyncio.run(_run())
+
     def test_update_ip_updates_entry_data_and_reloads(self) -> None:
         async def _run() -> None:
             entry = _make_config_entry(
@@ -262,6 +281,22 @@ class TestStartPrintService:
                 "supports_response", args[4] if len(args) > 4 else None
             )
             assert supports_response is SupportsResponse.OPTIONAL
+
+        asyncio.run(_run())
+
+    def test_registered_start_print_handler_takes_the_call_alone(self) -> None:
+        async def _run() -> None:
+            hass = MagicMock()
+            hass.config_entries.async_get_entry.return_value = None
+            await async_setup(hass, {})
+            handler = hass.services.async_register.call_args_list[1].args[2]
+
+            call = MagicMock()
+            call.data = {"entry_id": "ghost-404", "filename": "benchy.gcode"}
+            result = await handler(call)
+
+            assert result["success"] is False
+            assert "ghost-404" in _error_message(result)
 
         asyncio.run(_run())
 

--- a/custom_components/elegoo_printer/tests/test_services.py
+++ b/custom_components/elegoo_printer/tests/test_services.py
@@ -13,17 +13,26 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+import voluptuous as vol
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import SupportsResponse
 from homeassistant.exceptions import ConfigEntryError
 
 from custom_components.elegoo_printer import (
+    SERVICE_START_PRINT,
+    SERVICE_START_PRINT_SCHEMA,
     SERVICE_UPDATE_IP,
     SERVICE_UPDATE_IP_SCHEMA,
+    _async_start_print,
     _async_update_ip,
     async_setup,
 )
+from custom_components.elegoo_printer.cc2.client import ElegooCC2Client
 from custom_components.elegoo_printer.const import DOMAIN
+from custom_components.elegoo_printer.sdcp.exceptions import (
+    ElegooPrinterNotConnectedError,
+)
 
 
 def _make_hass_with_entry(*, entry: MagicMock) -> MagicMock:
@@ -70,8 +79,9 @@ class TestUpdateIpService:
             result = await async_setup(hass, {})
 
             assert result is True
-            assert hass.services.async_register.call_count == 1
-            args, kwargs = hass.services.async_register.call_args
+            # update_ip and start_print; this test pins the update_ip call.
+            assert hass.services.async_register.call_count == 2
+            args, kwargs = hass.services.async_register.call_args_list[0]
             assert args[0] == DOMAIN
             assert args[1] in (SERVICE_UPDATE_IP, "update_ip")
             # args[2] is the handler — must be a real callable.
@@ -208,5 +218,166 @@ class TestUpdateIpService:
             hass.config_entries.async_update_entry.assert_called_once_with(
                 entry, data={"ip_address": "198.51.100.7", "id": "p1"}
             )
+
+        asyncio.run(_run())
+
+
+def _make_cc2_entry(*, client: MagicMock, state: ConfigEntryState) -> MagicMock:
+    """Build a CC2 entry whose runtime_data.api.client is ``client``."""
+    entry = _make_config_entry(
+        entry_id="cc2-1", domain=DOMAIN, data={"ip_address": "192.0.2.5"}, state=state
+    )
+    entry.runtime_data.api.client = client
+    return entry
+
+
+def _cc2_client(*, error_code: int = 0) -> MagicMock:
+    """Build a client that passes the isinstance check and answers print_start."""
+    client = MagicMock(spec=ElegooCC2Client)
+    client.print_start = AsyncMock(return_value=error_code)
+    return client
+
+
+def _start_call(**extra: object) -> MagicMock:
+    call = MagicMock()
+    call.data = {"entry_id": "cc2-1", "filename": "benchy.gcode", **extra}
+    return call
+
+
+class TestStartPrintService:
+    """The start_print service starts a stored file on a CC2 entry only."""
+
+    def test_async_setup_registers_start_print_service(self) -> None:
+        async def _run() -> None:
+            hass = MagicMock()
+            await async_setup(hass, {})
+
+            args, kwargs = hass.services.async_register.call_args_list[1]
+            assert args[0] == DOMAIN
+            assert args[1] == SERVICE_START_PRINT
+            assert callable(args[2])
+            schema = kwargs.get("schema", args[3] if len(args) > 3 else None)
+            assert schema is SERVICE_START_PRINT_SCHEMA
+            supports_response = kwargs.get(
+                "supports_response", args[4] if len(args) > 4 else None
+            )
+            assert supports_response is SupportsResponse.OPTIONAL
+
+        asyncio.run(_run())
+
+    def test_schema_rejects_tray_outside_canvas(self) -> None:
+        # The printer accepts tray_id 4 with error_code 0 and prints from tray 0;
+        # the schema is the only place that catches it.
+        ok = SERVICE_START_PRINT_SCHEMA(
+            {"entry_id": "x", "filename": "a.gcode", "tray": 3}
+        )
+        assert ok["bed_leveling"] is True
+        with pytest.raises(vol.Invalid):
+            SERVICE_START_PRINT_SCHEMA(
+                {"entry_id": "x", "filename": "a.gcode", "tray": 4}
+            )
+        with pytest.raises(vol.Invalid):
+            SERVICE_START_PRINT_SCHEMA({"entry_id": "x", "filename": ""})
+
+    def test_start_print_without_tray(self) -> None:
+        async def _run() -> None:
+            client = _cc2_client()
+            entry = _make_cc2_entry(client=client, state=ConfigEntryState.LOADED)
+            hass = _make_hass_with_entry(entry=entry)
+
+            result = await _async_start_print(hass, _start_call())
+
+            assert result["success"] is True
+            # bed_leveling defaults to True in the schema; the handler falls
+            # back to the same when a programmatic call omits it.
+            client.print_start.assert_awaited_once_with(
+                "benchy.gcode", tray_id=None, bed_leveling=True
+            )
+
+        asyncio.run(_run())
+
+    def test_start_print_with_tray_without_leveling(self) -> None:
+        async def _run() -> None:
+            client = _cc2_client()
+            entry = _make_cc2_entry(client=client, state=ConfigEntryState.LOADED)
+            hass = _make_hass_with_entry(entry=entry)
+
+            result = await _async_start_print(
+                hass, _start_call(tray=2, bed_leveling=False)
+            )
+
+            assert result["success"] is True
+            client.print_start.assert_awaited_once_with(
+                "benchy.gcode", tray_id=2, bed_leveling=False
+            )
+
+        asyncio.run(_run())
+
+    def test_start_print_busy_printer_reports_failure(self) -> None:
+        async def _run() -> None:
+            client = _cc2_client(error_code=1009)
+            entry = _make_cc2_entry(client=client, state=ConfigEntryState.LOADED)
+            hass = _make_hass_with_entry(entry=entry)
+
+            result = await _async_start_print(hass, _start_call())
+
+            assert result["success"] is False
+            assert "1009" in _error_message(result)
+
+        asyncio.run(_run())
+
+    def test_start_print_not_connected_reports_failure(self) -> None:
+        async def _run() -> None:
+            client = _cc2_client()
+            client.print_start = AsyncMock(side_effect=ElegooPrinterNotConnectedError)
+            entry = _make_cc2_entry(client=client, state=ConfigEntryState.LOADED)
+            hass = _make_hass_with_entry(entry=entry)
+
+            result = await _async_start_print(hass, _start_call())
+
+            assert result["success"] is False
+            assert "not reachable" in _error_message(result)
+
+        asyncio.run(_run())
+
+    def test_start_print_refuses_non_cc2_client(self) -> None:
+        async def _run() -> None:
+            client = MagicMock()  # not an ElegooCC2Client
+            client.print_start = AsyncMock(return_value=0)
+            entry = _make_cc2_entry(client=client, state=ConfigEntryState.LOADED)
+            hass = _make_hass_with_entry(entry=entry)
+
+            result = await _async_start_print(hass, _start_call())
+
+            assert result["success"] is False
+            assert "Centauri Carbon 2" in _error_message(result)
+            client.print_start.assert_not_awaited()
+
+        asyncio.run(_run())
+
+    def test_start_print_unknown_entry_returns_error(self) -> None:
+        async def _run() -> None:
+            hass = MagicMock()
+            hass.config_entries.async_get_entry.return_value = None
+            call = MagicMock()
+            call.data = {"entry_id": "ghost-404", "filename": "benchy.gcode"}
+
+            result = await _async_start_print(hass, call)
+
+            assert result["success"] is False
+            assert "ghost-404" in _error_message(result)
+
+        asyncio.run(_run())
+
+    def test_start_print_not_loaded_entry_returns_error(self) -> None:
+        async def _run() -> None:
+            client = _cc2_client()
+            entry = _make_cc2_entry(client=client, state=ConfigEntryState.SETUP_RETRY)
+            hass = _make_hass_with_entry(entry=entry)
+
+            result = await _async_start_print(hass, _start_call())
+
+            assert result["success"] is False
+            client.print_start.assert_not_awaited()
 
         asyncio.run(_run())


### PR DESCRIPTION
Adds `elegoo_printer.start_print`, CC2 only: start a G-code file that is already in the printer's local storage, optionally on a chosen Canvas tray, with auto bed leveling on by default as in the slicer. Closes #412.

**What it sends** (method 1020):

```json
{"storage_media": "local", "filename": "<name>", "config": {"slot_map": [{"t": 0, "canvas_id": 0, "tray_id": <tray>}]}}
```

- no `tray` → `"slot_map": []`, the printer chooses;
- `bed_leveling` (default `true`, what ElegooSlicer sends on every job) → adds `"printer_check": true`; with `false` the key is omitted — omitted is the shape that was measured, and the printer then levels only when it decides to on its own;
- nothing else from the slicer's `config` object — not required, see the runs below.

**What it returns:** `{success, message|error}` with `supports_response=optional`, like `update_ip`. `error_code` 1009 (printer busy) and connection errors come back as `success: false` with the reason.

**Why it looks the way it does**

- Only for `ElegooCC2Client`; the SDCP transports are untouched, per #297.
- `tray` is validated in the schema (0–3) because the printer does not validate it: an out-of-range `tray_id`, or an entry without `t`/`canvas_id`, is acknowledged with `error_code 0` and silently printed from tray 0. So the response cannot be used to check the mapping, and the full entry is always sent.
- `bed_leveling` defaults to on, matching the slicer and the Elegoo app, so a plain call behaves like "print again" there; it costs about three minutes of leveling per print (measured with and without on the same file), which is why it is exposed as an option at all. #412 had suggested default-off; on reflection that is a per-user preference, not something a service should impose.
- Only tool 0 is mapped. Multi-tool `slot_map` and `canvas_id ≠ 0` are not covered — untested, and out of scope for "print this again".

**Files:** `cc2/client.py` (`print_start`), `__init__.py` (schema, handler, registration), `services.yaml`, README services section, CHANGELOG; tests in `tests/test_services.py` (9 cases: registration, schema bounds, no tray, tray + leveling, busy, not connected, non-CC2 client, unknown entry, entry not loaded) and `cc2/tests/test_start_print.py` (4 cases: exact payload with/without tray, `printer_check`, error code passthrough).

**Verification**

- `uv run ruff check .`, `uv run ruff format . --check`, `uv run pytest`: clean, 498 passed (Linux, pinned lock).
- On a Centauri Carbon 2 Combo, firmware 02.01.00.00, the exact payload shapes this service builds were sent over MQTT:
  - full entry for tray 3 with `config` containing only `slot_map` → `error_code 0`, Canvas loaded tray 3 (`active_tray_id` from method 2005), printed to completion;
  - `printer_check: true` → auto leveling ran (sub-status 2901, ~130 s) before the print; the same file without it did not level;
  - partial entry `{"tray_id": 3}` and out-of-range `{"tray_id": 4}` → `error_code 0`, printed from tray 0 — the reason for the schema bound and the full entry.
- Live on Home Assistant 2026.9.1 with this branch installed through HACS, called via the REST service API with `return_response`: `start_print` with `tray: 1` → `{"success": true}`, the printer left idle immediately, the Canvas loaded tray 1 (`active_tray_id` sensor `01`), the file printed; the same call 3 s later → `{"success": false, "error": "Printer is busy (error_code 1009)"}`.

**Second commit — a fix for `update_ip` as well.** The live test first failed with HTTP 500: `_async_start_print() missing 1 required positional argument: 'call'`. HA invokes a service handler with the `ServiceCall` alone; both `update_ip` (#404, shipped in v2.12.2) and the new handler were `(hass, call)` functions registered bare. `update_ip` reproduces the same 500 on the live instance. Both are now registered as `partial(handler, hass)`, and two tests invoke the callable actually passed to `async_register`, which the existing direct-call tests could not catch. (`docs/specs/spec-001` shows the bare registration in its code block; I left the spec untouched since it is marked completed.)

## Test plan

- [x] `uv run ruff check .` and `uv run ruff format . --check` pass (pinned lock, Linux)
- [x] `uv run pytest`: 498 passed — 16 new for `start_print` (handler paths, schema bounds, exact 1020 payloads, missing acknowledgement) and 2 that call the registered handlers the way HA does
- [x] Live on HA 2026.9.1 against a Centauri Carbon 2 Combo (fw 02.01.00.00), branch installed via HACS: `start_print` with a tray → printer starts, Canvas loads that tray; second call while printing → `success: false`, 1009; `update_ip` with an unknown entry → JSON error instead of HTTP 500
- [x] Greptile round-1 findings addressed in the third commit (missing acknowledgement reported as failure; README multi-tool wording); re-review 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
